### PR TITLE
fix: Corrigir a tag da imagem base do Node.js no Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 ARG NODE_VERSION="22.17.1"
-ARG BASE_VERSION="alpine3.19"
+ARG BASE_VERSION="alpine3.22"
 ARG OLD_IMAGE="bulk-send-webapp:latest"
 ARG KEEP_DAYS=60
 


### PR DESCRIPTION
## Description
### Type of Change
* [x] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Tests
* [ ] Other

### Motivation and Context
O pipeline de build estava falhando na etapa de criação da imagem Docker. O erro ocorria porque a tag da imagem base do Node.js especificada no Dockerfile não existia no Docker Hub, impedindo o processo de build e o deploy.

### Summary of Changes
Para corrigir a falha de build, a tag da imagem base no `Dockerfile` foi alterada para uma versão válida e existente no Docker Hub.

- **Antes:** `FROM node:22.17.1-alpine3.19`
- **Depois:** `FROM node:22.17.1-alpine3.22`

Esta mudança resolve o problema do build sem alterar a funcionalidade da aplicação.

### Demonstration
Não aplicável, pois a mudança é um bugfix no processo de build.