### PR TITLE
feat: add GroupSelectionListEmpty component and corresponding unit te…

### DIFF
--- a/src/__tests__/components/NewBroadcast/GroupSelection/GroupSelectionListEmpty.spec.ts
+++ b/src/__tests__/components/NewBroadcast/GroupSelection/GroupSelectionListEmpty.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import GroupSelectionListEmpty from '@/components/NewBroadcast/GroupSelection/GroupSelectionListEmpty.vue';
+
+const SELECTOR = {
+  root: '[data-test="empty"]',
+  text: '[data-test="empty-text"]',
+} as const;
+
+describe('GroupSelectionListEmpty.vue', () => {
+  it('renders empty state text', () => {
+    const wrapper = mount(GroupSelectionListEmpty, {
+      global: {
+        mocks: { $t: (key: string) => key },
+      },
+    });
+    expect(wrapper.find(SELECTOR.root).exists()).toBe(true);
+    expect(wrapper.find(SELECTOR.text).text()).toBe(
+      'new_broadcast.pages.select_groups.no_groups',
+    );
+  });
+});

--- a/src/components/NewBroadcast/GroupSelection/GroupSelectionListEmpty.vue
+++ b/src/components/NewBroadcast/GroupSelection/GroupSelectionListEmpty.vue
@@ -1,0 +1,15 @@
+<template>
+  <section
+    class="group-selection-list__empty"
+    data-test="empty"
+  >
+    <p
+      class="group-selection-list__empty-text"
+      data-test="empty-text"
+    >
+      {{ $t('new_broadcast.pages.select_groups.no_groups') }}
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts"></script>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Simple component to display missing group search results

### Summary of Changes
Added component and redering tests

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/oYQwtQhHR0YMbug78GbR3g/Bulk-send?node-id=177-3156&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->
<img width="1073" height="48" alt="image" src="https://github.com/user-attachments/assets/27441dd3-3dcf-4c3b-83cd-39b84e977f19" />
