### PR TITLE
feat: implement listAllGroups method

### DIFF
--- a/src/__tests__/stores/groups.spec.ts
+++ b/src/__tests__/stores/groups.spec.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi, beforeEach, type Mocked } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { useGroupsStore } from '@/stores/groups';
-import Groups from '@/api/resources/groups';
+import GroupsAPI from '@/api/resources/groups';
 import type { AxiosResponse } from 'axios';
-import type { Group } from '@/types/groups';
 
-// Mock API module used by the store
 vi.mock('@/api/resources/groups', () => ({
   default: {
     getGroups: vi.fn(),
@@ -18,31 +16,61 @@ describe('groups store', () => {
     vi.clearAllMocks();
   });
 
-  it('getGroups loads, stores data and toggles loading flag', async () => {
+  it('getGroups toggles loading and stores results and count', async () => {
     const store = useGroupsStore();
-
-    const mockGroups: Group[] = [
-      { id: 1, uuid: 'g-1', name: 'G1', memberCount: 10 },
-      { id: 2, uuid: 'g-2', name: 'G2', memberCount: 5 },
-    ];
-
-    const mocked = Groups as Mocked<typeof Groups>;
+    const mocked = GroupsAPI as Mocked<typeof GroupsAPI>;
     mocked.getGroups.mockResolvedValue({
-      data: { count: 2, results: mockGroups },
+      data: {
+        results: [{ id: 1, uuid: 'g1', name: 'G1', memberCount: 2 }],
+        count: 1,
+      },
     } as AxiosResponse);
 
     expect(store.loadingGroups).toBe(false);
-
-    const params = { limit: 9, offset: 0, name: '', order: 'name' } as any;
-    const promise = store.getGroups('proj-123', params);
+    const promise = store.getGroups('proj-1', { offset: 0, limit: 10 });
     expect(store.loadingGroups).toBe(true);
     await promise;
 
-    expect(mocked.getGroups).toHaveBeenCalledWith('proj-123', params);
-    expect(store.groupsCount).toBe(2);
-    expect(store.groups).toEqual(mockGroups);
+    expect(mocked.getGroups).toHaveBeenCalledWith('proj-1', {
+      offset: 0,
+      limit: 10,
+    });
+    expect(store.groups).toHaveLength(1);
+    expect(store.groupsCount).toBe(1);
+    expect(store.loadingGroups).toBe(false);
+  });
+
+  it('listAllGroups paginates until next is null and aggregates results', async () => {
+    const store = useGroupsStore();
+    const mocked = GroupsAPI as Mocked<typeof GroupsAPI>;
+
+    // Simulate 2 pages
+    mocked.getGroups
+      .mockResolvedValueOnce({
+        data: {
+          results: Array.from({ length: 2 }).map((_, i) => ({
+            id: i + 1,
+            uuid: `g${i + 1}`,
+            name: `G${i + 1}`,
+            memberCount: 1,
+          })),
+          next: 'has-next',
+        },
+      } as AxiosResponse)
+      .mockResolvedValueOnce({
+        data: {
+          results: [{ id: 3, uuid: 'g3', name: 'G3', memberCount: 1 }],
+          next: null,
+        },
+      } as AxiosResponse);
+
+    expect(store.loadingGroups).toBe(false);
+    const promise = store.listAllGroups('proj-1');
+    expect(store.loadingGroups).toBe(true);
+    await promise;
+
+    expect(mocked.getGroups).toHaveBeenCalledTimes(2);
+    expect(store.groups.map((g) => g.id)).toEqual([1, 2, 3]);
     expect(store.loadingGroups).toBe(false);
   });
 });
-
-

--- a/src/stores/groups.ts
+++ b/src/stores/groups.ts
@@ -17,5 +17,20 @@ export const useGroupsStore = defineStore('groups', {
       this.groupsCount = response.data.count;
       this.loadingGroups = false;
     },
+    async listAllGroups(projectUuid: string) {
+      this.loadingGroups = true;
+      const page = 1;
+      while (true) {
+        const response = await GroupsAPI.getGroups(projectUuid, {
+          offset: (page - 1) * 100,
+          limit: 100,
+        });
+        this.groups = [...this.groups, ...response.data.results];
+        if (response.data.next === null) {
+          break;
+        }
+      }
+      this.loadingGroups = false;
+    },
   },
 });


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
ContactImport will ned the full list of available groups

### Summary of Changes
Added action to iterate all pages and return the complete list of groups