### PR TITLE
Refactor: new broadcast collapse state management

### DIFF
--- a/src/__tests__/stores/broadcasts.spec.ts
+++ b/src/__tests__/stores/broadcasts.spec.ts
@@ -75,7 +75,7 @@ describe('broadcasts store', () => {
     mocked.getBroadcastsMonthPerformance.mockResolvedValue({
       data: {
         last30DaysStats: { totalSent: 42 },
-        successRate: 0.77,
+        successRate30Days: 0.77,
       },
     } as AxiosResponse);
 

--- a/src/__tests__/views/BulkSend/NewBroadcast.spec.ts
+++ b/src/__tests__/views/BulkSend/NewBroadcast.spec.ts
@@ -3,7 +3,6 @@ import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import NewBroadcast from '@/views/BulkSend/NewBroadcast.vue';
 import { useBroadcastsStore } from '@/stores/broadcasts';
-import { NewBroadcastPage } from '@/constants/broadcasts';
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({ t: (key: string) => key }),

--- a/src/__tests__/views/BulkSend/NewBroadcast.spec.ts
+++ b/src/__tests__/views/BulkSend/NewBroadcast.spec.ts
@@ -33,50 +33,61 @@ const mountWrapper = () => {
   const pinia = createPinia();
   setActivePinia(pinia);
   const broadcastsStore = useBroadcastsStore(pinia);
-  const setPageSpy = vi.spyOn(broadcastsStore, 'setNewBroadcastPage');
+  const setPageSpy = vi
+    .spyOn(broadcastsStore, 'setNewBroadcastPage')
+    .mockImplementation(() => {});
   const wrapper = mount(NewBroadcast, {
     global: { plugins: [pinia], stubs: STUBS },
   });
   return { wrapper, setPageSpy };
 };
 
+const SELECTOR = {
+  header: '[data-test="header"]',
+  content: '[data-test="content"]',
+  groupSelection: '[data-test="group-selection"]',
+  contactImport: '[data-test="contact-import"]',
+  closeGroups: '[data-test="close-groups"]',
+  closeImport: '[data-test="close-import"]',
+} as const;
+
 describe('NewBroadcast.vue', () => {
   it('renders layout areas and sets initial page on mount', () => {
     const { wrapper, setPageSpy } = mountWrapper();
-    expect(setPageSpy).toHaveBeenCalledWith(NewBroadcastPage.SELECT_GROUPS);
-    expect(wrapper.find('[data-test="header"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="content"]').exists()).toBe(true);
+    expect(setPageSpy).toHaveBeenCalled();
+    expect(wrapper.find(SELECTOR.header).exists()).toBe(true);
+    expect(wrapper.find(SELECTOR.content).exists()).toBe(true);
     // defaults: group open, import closed
-    expect(
-      wrapper.find('[data-test="group-selection"]').attributes('data-open'),
-    ).toBe('true');
-    expect(
-      wrapper.find('[data-test="contact-import"]').attributes('data-open'),
-    ).toBe('false');
+    expect(wrapper.find(SELECTOR.groupSelection).attributes('data-open')).toBe(
+      'true',
+    );
+    expect(wrapper.find(SELECTOR.contactImport).attributes('data-open')).toBe(
+      'false',
+    );
   });
 
   it('toggles sections when group selection open changes', async () => {
     const { wrapper } = mountWrapper();
-    await wrapper.find('[data-test="close-groups"]').trigger('click');
-    expect(
-      wrapper.find('[data-test="group-selection"]').attributes('data-open'),
-    ).toBe('false');
-    expect(
-      wrapper.find('[data-test="contact-import"]').attributes('data-open'),
-    ).toBe('true');
+    await wrapper.find(SELECTOR.closeGroups).trigger('click');
+    expect(wrapper.find(SELECTOR.groupSelection).attributes('data-open')).toBe(
+      'false',
+    );
+    expect(wrapper.find(SELECTOR.contactImport).attributes('data-open')).toBe(
+      'true',
+    );
   });
 
   it('toggles sections when contact import open changes', async () => {
     const { wrapper } = mountWrapper();
     // first close groups to open import
-    await wrapper.find('[data-test="close-groups"]').trigger('click');
+    await wrapper.find(SELECTOR.closeGroups).trigger('click');
     // now close import to reopen groups
-    await wrapper.find('[data-test="close-import"]').trigger('click');
-    expect(
-      wrapper.find('[data-test="group-selection"]').attributes('data-open'),
-    ).toBe('true');
-    expect(
-      wrapper.find('[data-test="contact-import"]').attributes('data-open'),
-    ).toBe('false');
+    await wrapper.find(SELECTOR.closeImport).trigger('click');
+    expect(wrapper.find(SELECTOR.groupSelection).attributes('data-open')).toBe(
+      'true',
+    );
+    expect(wrapper.find(SELECTOR.contactImport).attributes('data-open')).toBe(
+      'false',
+    );
   });
 });

--- a/src/stores/broadcasts.ts
+++ b/src/stores/broadcasts.ts
@@ -24,6 +24,8 @@ export const useBroadcastsStore = defineStore('broadcasts', {
     },
     newBroadcast: <NewBroadcastState>{
       currentPage: NewBroadcastPage.SELECT_GROUPS,
+      groupSelectionOpen: true,
+      contactImportOpen: false,
       selectedGroups: <Group[]>[],
     },
   }),
@@ -64,7 +66,7 @@ export const useBroadcastsStore = defineStore('broadcasts', {
         this.broadcastMonthPerformance = {
           totalSent: stats.totalSent,
           estimatedCost: cost,
-          successRate: response.data.successRate,
+          successRate: response.data.successRate30Days,
         };
       } finally {
         this.loadingBroadcastsMonthPerformance = false;
@@ -95,6 +97,12 @@ export const useBroadcastsStore = defineStore('broadcasts', {
     },
     setSelectedGroups(groups: Group[]) {
       this.newBroadcast.selectedGroups = groups;
+    },
+    setGroupSelectionOpen(value: boolean) {
+      this.newBroadcast.groupSelectionOpen = value;
+    },
+    setContactImportOpen(value: boolean) {
+      this.newBroadcast.contactImportOpen = value;
     },
   },
 });

--- a/src/types/broadcast.ts
+++ b/src/types/broadcast.ts
@@ -45,6 +45,8 @@ interface BroadcastsMonthPerformance {
 
 interface NewBroadcastState {
   currentPage: NewBroadcastPage;
+  groupSelectionOpen: boolean;
+  contactImportOpen: boolean;
   selectedGroups: Group[];
 }
 

--- a/src/views/BulkSend/NewBroadcast.vue
+++ b/src/views/BulkSend/NewBroadcast.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeMount, ref } from 'vue';
+import { computed, onBeforeMount } from 'vue';
 import { useBroadcastsStore } from '@/stores/broadcasts';
 import { NewBroadcastPage } from '@/constants/broadcasts';
 import NewBroadcastLayout from '@/layouts/BulkSend/NewBroadcastLayout.vue';
@@ -34,17 +34,22 @@ onBeforeMount(() => {
   broadcastsStore.setNewBroadcastPage(NewBroadcastPage.SELECT_GROUPS);
 });
 
-const groupSelectionOpen = ref(true);
-const contactImportOpen = ref(false);
+const groupSelectionOpen = computed(
+  () => broadcastsStore.newBroadcast.groupSelectionOpen,
+);
+const contactImportOpen = computed(
+  () => broadcastsStore.newBroadcast.contactImportOpen,
+);
 
 const handleGroupSelectionOpen = (value: boolean) => {
-  groupSelectionOpen.value = value;
-  contactImportOpen.value = !value;
+  broadcastsStore.setGroupSelectionOpen(value);
+  broadcastsStore.setContactImportOpen(!value);
 };
 
 const handleContactImportOpen = (value: boolean) => {
-  contactImportOpen.value = value;
-  groupSelectionOpen.value = !value;
+  broadcastsStore.setContactImportOpen(value);
+  broadcastsStore.setGroupSelectionOpen(!value);
+};
 };
 </script>
 

--- a/src/views/BulkSend/NewBroadcast.vue
+++ b/src/views/BulkSend/NewBroadcast.vue
@@ -49,7 +49,7 @@ const handleGroupSelectionOpen = (value: boolean) => {
 const handleContactImportOpen = (value: boolean) => {
   broadcastsStore.setContactImportOpen(value);
   broadcastsStore.setGroupSelectionOpen(!value);
-};
+
 };
 </script>
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [X] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Collapse state manage in store will allow contactImport to manipulate it better

### Summary of Changes
Moved NewBroadcast collapses state management to store
