### PR TITLE
fix: federated app mount lifecycle

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -133,6 +133,11 @@ export default defineConfig({
           requiredVersion: pkg.dependencies['vue-i18n'],
           eager: true,
         },
+        pinia: {
+          singleton: true,
+          requiredVersion: pkg.dependencies.pinia,
+          eager: true,
+        },
       },
     }),
   ],

--- a/src/api/requests.ts
+++ b/src/api/requests.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import '@/utils/piniaSetup';
 import type { AxiosInstance } from 'axios';
 import camelcaseKeys from 'camelcase-keys';
 import { useAuthStore } from '@/stores/auth';

--- a/src/utils/piniaSetup.ts
+++ b/src/utils/piniaSetup.ts
@@ -1,0 +1,16 @@
+import { createPinia, setActivePinia, getActivePinia } from 'pinia';
+
+export function setupPinia() {
+  let pinia = getActivePinia();
+
+  //Pinia is initialized for the federated module
+  if (!pinia) {
+    pinia = createPinia();
+    setActivePinia(pinia);
+  }
+
+  console.log('[BulkSend - piniaSetup.ts] Pinia initialized', pinia);
+  return pinia;
+}
+
+setupPinia();


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
App was being mounted before sharedStore was available and set the token and project

### Summary of Changes
Updated how sharedStore is initialized and added pinia to module federation deduping strategy as needed
