### PR TITLE
fix: replace section with template in RecentSendsList.vue for proper …

### DIFF
--- a/src/components/HomeBulkSend/RecentSendsList.vue
+++ b/src/components/HomeBulkSend/RecentSendsList.vue
@@ -4,13 +4,13 @@
       v-if="!loading"
       class="recent-sends-list__content"
     >
-      <section v-if="recentSends.length > 0">
+      <template v-if="recentSends.length > 0">
         <SendElement
           v-for="send in recentSends"
           :key="send.id"
           :send="send"
         />
-      </section>
+      </template>
       <section
         v-else
         class="recent-sends-list__empty"


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
An extra section was added that removed the gap between SendElements listage since it was a DOM element without display

### Summary of Changes
Changed from section to template, since it's only needed for a conditional redering

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/oYQwtQhHR0YMbug78GbR3g/Bulk-send?node-id=113-1523&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<img width="1311" height="332" alt="image" src="https://github.com/user-attachments/assets/63981803-616e-41e4-b66e-e8869e343218" />