### PR TITLE
feat: add TemplatePreviewModal component with loading state and templ…

### DIFF
--- a/src/__tests__/components/modals/TemplatePreviewModal.spec.ts
+++ b/src/__tests__/components/modals/TemplatePreviewModal.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import TemplatePreviewModal from '@/components/modals/TemplatePreviewModal.vue';
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }));
+
+let mockGetTemplate: any;
+vi.mock('@/stores/templates', () => ({
+  useTemplatesStore: () => ({ getTemplate: mockGetTemplate }),
+}));
+
+const STUBS = {
+  UnnnicModalDialog: {
+    props: ['modelValue', 'title', 'showCloseIcon', 'showActionsDivider'],
+    emits: ['update:model-value'],
+    template:
+      '<div data-test="modal" :data-open="modelValue"><slot /><button data-test="close" @click="$emit(\'update:model-value\', false)"></button></div>',
+  },
+  UnnnicTemplatePreview: {
+    props: ['template'],
+    template:
+      '<div\n' +
+      '  data-test="preview"\n' +
+      "  :data-header-type=\"template && template.header ? (template.header.type || '' ) : ''\"\n" +
+      "  :data-media-type=\"template && template.header ? (template.header.mediaType || '' ) : ''\"\n" +
+      '  :data-body="template && template.body ? template.body : \'\'"\n' +
+      '  :data-footer="template && template.footer ? template.footer : \'\'"\n' +
+      '/>',
+  },
+} as const;
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('TemplatePreviewModal.vue', () => {
+  beforeEach(() => {
+    mockGetTemplate = vi.fn();
+  });
+
+  it('shows loading then renders preview with mapped template', async () => {
+    const deferred = createDeferred<any>();
+    mockGetTemplate.mockReturnValue(deferred.promise);
+
+    const wrapper = mount(TemplatePreviewModal, {
+      props: { modelValue: true, templateId: 123 },
+      global: { stubs: STUBS, mocks: { $t: (k: string) => k } },
+    });
+
+    expect(wrapper.find('[data-test="group-list-loading"]').exists()).toBe(
+      true,
+    );
+
+    // resolve API call
+    deferred.resolve({
+      data: {
+        uuid: 't-1',
+        name: 'Welcome',
+        createdOn: '2024-01-01T00:00:00Z',
+        category: 'CAT',
+        language: 'en',
+        header: { type: 'IMAGE' },
+        body: { text: 'Body' },
+        footer: { text: 'Footer' },
+        status: 'A',
+      },
+    });
+
+    // allow then/finally microtasks and DOM update to flush
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+    await wrapper.vm.$nextTick();
+
+    const loading = wrapper.find('[data-test="group-list-loading"]');
+    expect(loading.exists()).toBe(false);
+    const preview = wrapper.find('[data-test="preview"]');
+    expect(preview.exists()).toBe(true);
+    expect(preview.attributes('data-header-type')).toBe('MEDIA');
+    expect(preview.attributes('data-media-type')).toBe('IMAGE');
+    expect(preview.attributes('data-body')).toBe('Body');
+    expect(preview.attributes('data-footer')).toBe('Footer');
+  });
+
+  it('emits update:modelValue when modal emits update:model-value', async () => {
+    mockGetTemplate.mockResolvedValue({ data: { body: { text: '' } } });
+
+    const wrapper = mount(TemplatePreviewModal, {
+      props: { modelValue: true, templateId: 1 },
+      global: { stubs: STUBS, mocks: { $t: (k: string) => k } },
+    });
+
+    await wrapper.find('[data-test="close"]').trigger('click');
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([false]);
+  });
+});

--- a/src/components/modals/TemplatePreviewModal.vue
+++ b/src/components/modals/TemplatePreviewModal.vue
@@ -1,0 +1,71 @@
+<template>
+  <UnnnicModalDialog
+    class="template-preview-modal"
+    :modelValue="modelValue"
+    :title="$t('modals.template_preview.title')"
+    showCloseIcon
+    showActionsDivider
+    @update:model-value="handleUpdateModelValue"
+  >
+    <section
+      v-if="loading"
+      class="template-preview-modal__loading"
+      data-test="group-list-loading"
+    >
+      <img
+        :src="weniLoading"
+        width="40"
+        height="40"
+      />
+    </section>
+    <UnnnicTemplatePreview
+      v-else
+      :template="template"
+    />
+  </UnnnicModalDialog>
+</template>
+
+<script setup lang="ts">
+import { onBeforeMount, ref } from 'vue';
+import { useTemplatesStore } from '@/stores/templates';
+import { formatTemplateToPreview } from '@/utils/templates';
+import weniLoading from '@/assets/images/weni-loading.svg';
+import type { TemplatePreview } from '@/types/template';
+
+const templatesStore = useTemplatesStore();
+
+const template = ref<TemplatePreview | null>(null);
+const loading = ref(false);
+
+const props = defineProps<{
+  modelValue: boolean;
+  templateId: number;
+}>();
+
+const emit = defineEmits(['update:modelValue']);
+
+onBeforeMount(() => {
+  loading.value = true;
+  templatesStore
+    .getTemplate(props.templateId)
+    .then((response) => {
+      template.value = formatTemplateToPreview(response.data);
+    })
+    .finally(() => {
+      loading.value = false;
+    });
+});
+
+const handleUpdateModelValue = (value: boolean) => {
+  emit('update:modelValue', value);
+};
+</script>
+
+<style scoped lang="scss">
+.template-preview-modal {
+  :deep(.unnnic-modal-dialog__container__content) {
+    background-color: $unnnic-color-background-lightest;
+    justify-items: center;
+  }
+}
+</style>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Template preview inside a modal

### Summary of Changes
Added component and tests

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/oYQwtQhHR0YMbug78GbR3g/Bulk-send?node-id=163-6824&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<img width="1313" height="877" alt="image" src="https://github.com/user-attachments/assets/5bbb251e-9fd8-4da5-a9df-246a1606cab4" />
