### PR TITLE
feat: implement search input clear functionality in RecentSends search

### DIFF
--- a/src/components/HomeBulkSend/RecentSends.vue
+++ b/src/components/HomeBulkSend/RecentSends.vue
@@ -31,6 +31,9 @@
           iconLeft="search-1"
           :placeholder="$t('home.recent_sends.search_placeholder')"
           :modelValue="search"
+          :iconRight="searchClearIcon"
+          iconRightClickable
+          @icon-right-click="handleSearchClear"
           @update:model-value="handleSearchUpdate"
         />
 
@@ -92,6 +95,10 @@ const showMissingRecentSends = computed(
     !isSearching.value,
 );
 
+const searchClearIcon = computed(() => {
+  return search.value !== '' ? 'close' : undefined;
+});
+
 onBeforeMount(() => {
   fetchRecentSends();
 });
@@ -106,6 +113,11 @@ const handleDateRangeUpdate = useDebounceFn((value: DateRange) => {
   dateRange.value = value;
   handlePageUpdate(1);
 }, 500);
+
+const handleSearchClear = () => {
+  search.value = '';
+  isSearching.value = false;
+};
 
 const handleStartNewSend = () => {
   // TODO: implement redirect to new send page


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Recent sends search was missing the clear action

### Summary of Changes
Added search clear icon and action

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/oYQwtQhHR0YMbug78GbR3g/Bulk-send?node-id=249-2148&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<img width="1309" height="254" alt="image" src="https://github.com/user-attachments/assets/2060a161-0a19-49b5-bd07-4f4706016f58" />
