### PR TITLE
Feat: template preview variables

### DIFF
--- a/src/__tests__/components/NewBroadcast/TemplateSelection/TemplateSelectionPreview.spec.ts
+++ b/src/__tests__/components/NewBroadcast/TemplateSelection/TemplateSelectionPreview.spec.ts
@@ -86,7 +86,7 @@ describe('TemplateSelectionPreview.vue', () => {
       .find(SELECTOR.previewComponent)
       .attributes('data-body');
     // {{1}} becomes bold style marker *{{1}}* then replaced with Alice
-    expect(bodyText).toContain('Hello Alice and *{{2}}*');
+    expect(bodyText).toContain('Hello *Alice* and *{{2}}*');
   });
 
   it('maps non-TEXT header to MEDIA, keeps mediaType, and includes footer', async () => {

--- a/src/__tests__/components/NewBroadcast/TemplateSelection/TemplateSelectionPreview.spec.ts
+++ b/src/__tests__/components/NewBroadcast/TemplateSelection/TemplateSelectionPreview.spec.ts
@@ -1,25 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
 import TemplateSelectionPreview from '@/components/NewBroadcast/TemplateSelection/TemplateSelectionPreview.vue';
 import { useBroadcastsStore } from '@/stores/broadcasts';
-import type { Template } from '@/types/template';
-import { TemplateCategory, TemplateStatus } from '@/constants/templates';
 
-const SELECTOR = {
-  title: '[data-test="template-preview-title"]',
-  name: '[data-test="template-preview-name"]',
-  nameValue: '[data-test="template-preview-name-value"]',
-  content: '[data-test="template-preview-content"]',
-  missing: '[data-test="template-preview-missing"]',
-  preview: '[data-test="template-preview-component"]',
-} as const;
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
 
-const stubs = {
+const STUBS = {
   UnnnicTemplatePreview: {
     props: ['template'],
-    // Expose mapped template data via attributes for assertions
     template:
       '<div\n' +
       '  data-test="template-preview-component"\n' +
@@ -29,62 +21,91 @@ const stubs = {
       '  :data-footer="template && template.footer ? template.footer : \'\'"\n' +
       '/>',
   },
-};
+} as const;
 
-const mountWithStore = () => {
+const SELECTOR = {
+  root: '[data-test="template-preview"]',
+  header: '[data-test="template-preview-header"]',
+  title: '[data-test="template-preview-title"]',
+  name: '[data-test="template-preview-name"]',
+  nameValue: '[data-test="template-preview-name-value"]',
+  content: '[data-test="template-preview-content"]',
+  missing: '[data-test="template-preview-missing"]',
+  previewComponent: '[data-test="template-preview-component"]',
+} as const;
+
+const mountWrapper = (opts?: {
+  withTemplate?: boolean;
+  variables?: (string | undefined)[];
+}) => {
   const pinia = createPinia();
   setActivePinia(pinia);
   const broadcastsStore = useBroadcastsStore(pinia);
+
+  if (opts?.withTemplate) {
+    broadcastsStore.newBroadcast.selectedTemplate = {
+      name: 'Welcome',
+      body: { text: 'Hello {{1}} and {{2}}' },
+      footer: { text: 'Footer' },
+      header: { type: 'TEXT', text: 'Header' },
+      buttons: [],
+    } as any;
+  } else {
+    broadcastsStore.newBroadcast.selectedTemplate = undefined;
+  }
+
   const wrapper = mount(TemplateSelectionPreview, {
-    global: {
-      plugins: [pinia],
-      stubs,
-      mocks: { $t: (key: string) => key },
-    },
+    props: { variablesToReplace: opts?.variables },
+    global: { plugins: [pinia], stubs: STUBS, mocks: { $t: (k: string) => k } },
   });
   return { wrapper, broadcastsStore };
 };
 
 describe('TemplateSelectionPreview.vue', () => {
-  it('renders empty state when no template selected', () => {
-    const { wrapper } = mountWithStore();
+  it('renders title and missing state when no template selected', () => {
+    const { wrapper } = mountWrapper({ withTemplate: false });
     expect(wrapper.find(SELECTOR.title).exists()).toBe(true);
     expect(wrapper.find(SELECTOR.missing).exists()).toBe(true);
-    expect(wrapper.find(SELECTOR.name).exists()).toBe(false);
-    expect(wrapper.find(SELECTOR.preview).exists()).toBe(false);
+    expect(wrapper.find(SELECTOR.previewComponent).exists()).toBe(false);
   });
 
-  it('renders preview with mapped template when a template is selected', async () => {
-    const { wrapper, broadcastsStore } = mountWithStore();
+  it('renders name and UnnnicTemplatePreview when template selected', () => {
+    const { wrapper } = mountWrapper({ withTemplate: true });
+    expect(wrapper.find(SELECTOR.name).exists()).toBe(true);
+    expect(wrapper.find(SELECTOR.nameValue).text()).toBe('Welcome');
+    expect(wrapper.find(SELECTOR.previewComponent).exists()).toBe(true);
+  });
 
-    const template: Template = {
-      uuid: 't-1',
+  it('formats body to bold placeholders and replaces with variables', () => {
+    const { wrapper } = mountWrapper({
+      withTemplate: true,
+      variables: ['Alice', undefined],
+    });
+
+    const bodyText = wrapper
+      .find(SELECTOR.previewComponent)
+      .attributes('data-body');
+    // {{1}} becomes bold style marker *{{1}}* then replaced with Alice
+    expect(bodyText).toContain('Hello Alice and *{{2}}*');
+  });
+
+  it('maps non-TEXT header to MEDIA, keeps mediaType, and includes footer', async () => {
+    const { wrapper, broadcastsStore } = mountWrapper({ withTemplate: false });
+
+    broadcastsStore.setSelectedTemplate({
       name: 'Welcome Msg',
-      createdOn: '2024-01-01T00:00:00Z',
-      category: TemplateCategory.MARKETING,
-      language: 'en',
-      header: { type: 'IMAGE' }, // should be mapped to MEDIA with mediaType IMAGE
-      body: { text: 'Hello, world!' },
+      header: { type: 'IMAGE' },
+      body: { text: 'Hello' },
       footer: { text: 'Bye' },
-      buttons: [{ type: 'TEXT', text: 'OK' }],
-      status: TemplateStatus.APPROVED,
-      variableCount: 0,
-    };
+      buttons: [],
+    } as any);
 
-    broadcastsStore.setSelectedTemplate(template);
     await nextTick();
 
-    // name and preview should render
-    expect(wrapper.find(SELECTOR.name).exists()).toBe(true);
-    expect(wrapper.find(SELECTOR.nameValue).text()).toBe('Welcome Msg');
-    const preview = wrapper.find(SELECTOR.preview);
+    const preview = wrapper.find(SELECTOR.previewComponent);
     expect(preview.exists()).toBe(true);
-
-    // header mapping assertions
     expect(preview.attributes('data-header-type')).toBe('MEDIA');
     expect(preview.attributes('data-media-type')).toBe('IMAGE');
-    // body/footer mapping assertions
-    expect(preview.attributes('data-body')).toBe('Hello, world!');
     expect(preview.attributes('data-footer')).toBe('Bye');
   });
 });

--- a/src/components/NewBroadcast/TemplateSelection/TemplateSelectionList.vue
+++ b/src/components/NewBroadcast/TemplateSelection/TemplateSelectionList.vue
@@ -129,7 +129,7 @@ const handleRowClick = (item: TemplateRow) => {
     (template) =>
       template.uuid === item.uuid && template.language === item.language,
   );
-  broadcastsStore.setSelectedTemplate(template ?? null);
+  broadcastsStore.setSelectedTemplate(template);
 };
 
 const handlePageUpdate = (page: number) => {

--- a/src/components/NewBroadcast/TemplateSelection/TemplateSelectionPreview.vue
+++ b/src/components/NewBroadcast/TemplateSelection/TemplateSelectionPreview.vue
@@ -57,6 +57,10 @@ import { computed } from 'vue';
 import { useBroadcastsStore } from '@/stores/broadcasts';
 import { formatTemplateToPreview } from '@/utils/templates';
 
+const props = defineProps<{
+  variablesToReplace?: (string | undefined)[];
+}>();
+
 const broadcastsStore = useBroadcastsStore();
 
 const selectedTemplate = computed(() => {
@@ -66,8 +70,22 @@ const selectedTemplate = computed(() => {
 
   const selectedTemplate = broadcastsStore.newBroadcast.selectedTemplate;
 
-  return formatTemplateToPreview(selectedTemplate);
+  return formatTemplateToPreview(selectedTemplate, bodyFormatter);
 });
+
+const bodyFormatter = (body: string) => {
+  let newBody = body.replace(/{{(\d+)}}/g, '*{{$1}}*');
+
+  if (props.variablesToReplace && props.variablesToReplace.length > 0) {
+    props.variablesToReplace.forEach((variable, index) => {
+      if (variable) {
+        newBody = newBody.replace(`{{${index + 1}}}`, variable);
+      }
+    });
+  }
+
+  return newBody;
+};
 </script>
 
 <style scoped lang="scss">
@@ -121,6 +139,21 @@ const selectedTemplate = computed(() => {
 
     @include unnnic-text-body-gt;
     color: $unnnic-color-neutral-cloudy;
+  }
+
+  &__content-preview {
+    :deep(strong) {
+      font-weight: $unnnic-font-weight-bold;
+      color: $unnnic-color-neutral-dark;
+    }
+
+    :deep(i) {
+      font-style: italic;
+    }
+
+    :deep(tt) {
+      font-family: monospace;
+    }
   }
 }
 </style>

--- a/src/stores/broadcasts.ts
+++ b/src/stores/broadcasts.ts
@@ -106,7 +106,7 @@ export const useBroadcastsStore = defineStore('broadcasts', {
     setContactImportOpen(value: boolean) {
       this.newBroadcast.contactImportOpen = value;
     },
-    setSelectedTemplate(template: Template | null) {
+    setSelectedTemplate(template?: Template) {
       this.newBroadcast.selectedTemplate = template;
     },
   },

--- a/src/stores/broadcasts.ts
+++ b/src/stores/broadcasts.ts
@@ -27,8 +27,8 @@ export const useBroadcastsStore = defineStore('broadcasts', {
       currentPage: NewBroadcastPage.SELECT_GROUPS,
       groupSelectionOpen: true,
       contactImportOpen: false,
-      selectedGroups: <Group[]>[],
-      selectedTemplate: <Template | null>null,
+      selectedGroups: [],
+      selectedTemplate: undefined,
     },
   }),
   actions: {

--- a/src/types/broadcast.ts
+++ b/src/types/broadcast.ts
@@ -48,7 +48,7 @@ interface NewBroadcastState {
   groupSelectionOpen: boolean;
   contactImportOpen: boolean;
   selectedGroups: Group[];
-  selectedTemplate: Template | null;
+  selectedTemplate?: Template;
 }
 
 export type {

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -22,10 +22,15 @@ const formatTemplateHeaderToPreview = (
   return header;
 };
 
-const formatTemplateToPreview = (template: Template): TemplatePreview => {
+const formatTemplateToPreview = (
+  template: Template,
+  bodyFormatter?: (body: string) => string,
+): TemplatePreview => {
   return {
     ...template,
-    body: template.body.text,
+    body: bodyFormatter
+      ? bodyFormatter(template.body.text)
+      : template.body.text,
     footer: template.footer?.text,
     buttons: template.buttons,
     header: formatTemplateHeaderToPreview(template.header),


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Variables need to be replaceable and bold in the preview

### Summary of Changes
Added bodyFormatter to replace variables and make them bold

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/oYQwtQhHR0YMbug78GbR3g/Bulk-send?node-id=207-1197&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<img width="424" height="442" alt="image" src="https://github.com/user-attachments/assets/a83ef00f-68dc-40cb-bb49-e6fb86000d98" />
