### PR TITLE
feat: enhance NewBroadcastNavigator to conditionally disable variables step

### DIFF
--- a/src/__tests__/components/NewBroadcast/NewBroadcastNavigator.spec.ts
+++ b/src/__tests__/components/NewBroadcast/NewBroadcastNavigator.spec.ts
@@ -52,4 +52,23 @@ describe('NewBroadcastNavigator.vue', () => {
       'new_broadcast.pages.confirm_and_send.title',
     );
   });
+
+  it('disables variables page label when on confirm step and no variables', async () => {
+    const { wrapper, broadcastsStore } = mountWithStore();
+    // Confirm step without selected template (no variableCount)
+    broadcastsStore.setNewBroadcastPage(NewBroadcastPage.CONFIRM_AND_SEND);
+    await nextTick();
+
+    const nav = wrapper.find(SELECTOR.navigator);
+    const pages = nav.attributes('data-pages')?.split('|') as string[];
+    expect(pages[2]).toBe(
+      'new_broadcast.pages.select_variables_disabled.title',
+    );
+
+    // When a template with variables is selected, label reverts to normal
+    broadcastsStore.setSelectedTemplate({ variableCount: 2 } as any);
+    await nextTick();
+    const pages2 = nav.attributes('data-pages')?.split('|') as string[];
+    expect(pages2[2]).toBe('new_broadcast.pages.select_variables.title');
+  });
 });

--- a/src/components/NewBroadcast/NewBroadcastNavigator.vue
+++ b/src/components/NewBroadcast/NewBroadcastNavigator.vue
@@ -1,6 +1,9 @@
 <template>
   <UnnnicNavigator
-    class="new-broadcast-navigator"
+    :class="{
+      'new-broadcast-navigator': true,
+      'new-broadcast-navigator--disabled-variables-page': disabledVariablesPage,
+    }"
     :pages="pages"
     :activePage="currentPage"
   />
@@ -16,21 +19,46 @@ const { t } = useI18n();
 
 const broadcastsStore = useBroadcastsStore();
 
-const getPageLabel = (page: NewBroadcastPage) => {
-  return t(`new_broadcast.pages.${page}.title`);
-};
-
-const pages = Object.values(NewBroadcastPage).map((page) => getPageLabel(page));
+const disabledVariablesPage = computed(() => {
+  return (
+    broadcastsStore.newBroadcast.currentPage ===
+      NewBroadcastPage.CONFIRM_AND_SEND &&
+    !broadcastsStore.newBroadcast.selectedTemplate?.variableCount
+  );
+});
 
 const currentPage = computed(() => {
   return getPageLabel(broadcastsStore.newBroadcast.currentPage);
 });
+
+const pages = computed(() =>
+  Object.values(NewBroadcastPage).map((page) => getPageLabel(page)),
+);
+
+const getPageLabel = (page: NewBroadcastPage) => {
+  if (
+    disabledVariablesPage.value &&
+    page === NewBroadcastPage.SELECT_VARIABLES
+  ) {
+    return t('new_broadcast.pages.select_variables_disabled.title');
+  }
+
+  return t(`new_broadcast.pages.${page}.title`);
+};
 </script>
 
 <style scoped lang="scss">
 .new-broadcast-navigator {
   :deep(.unnnic-navigator-pages__page) {
     max-width: unset;
+  }
+
+  &--disabled-variables-page {
+    :nth-child(3) {
+      :deep(.unnnic-navigator-pages__page-progress) {
+        background-color: $unnnic-color-neutral-clean;
+      }
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Variables step must be displayed as disabled  when a template with no variables is selected

### Summary of Changes
Updated navigator with disabled logic
Obs: Discussing with the design about the boldness of the navigator labels since they are not the design system's default

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/oYQwtQhHR0YMbug78GbR3g/Bulk-send?node-id=113-9057&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<img width="1264" height="621" alt="image" src="https://github.com/user-attachments/assets/ddc647d4-3e98-4b62-9d9f-cd1428ff91e0" />