### PR TITLE
Feat: template selection channel filter

### DIFF
--- a/src/__tests__/components/NewBroadcast/TemplateSelection/TemplateSelection.spec.ts
+++ b/src/__tests__/components/NewBroadcast/TemplateSelection/TemplateSelection.spec.ts
@@ -15,6 +15,8 @@ vi.mock('@vueuse/core', () => ({ useDebounceFn: (fn: any) => fn }));
 
 const SELECTOR = {
   filtersSetSearch: '[data-test="set-search"]',
+  filtersSetChannel: '[data-test="set-channel"]',
+  filtersClearChannel: '[data-test="clear-channel"]',
   listNext: '[data-test="next"]',
   listSortAsc: '[data-test="sort-asc"]',
   listSortDesc: '[data-test="sort-desc"]',
@@ -26,10 +28,14 @@ const stubs = {
   UnnnicDisclaimer: { template: '<div data-test="disclaimer" />' },
   TemplateSelectionPreview: { template: '<div data-test="preview" />' },
   TemplateSelectionFilters: {
-    props: ['search'],
-    emits: ['update:search'],
+    props: ['search', 'channel'],
+    emits: ['update:search', 'update:channel'],
     template:
-      '<div data-test="filters"><button data-test="set-search" @click="$emit(\'update:search\', \'hello\')">set search</button></div>',
+      '<div data-test="filters">\n' +
+      '  <button data-test="set-search" @click="$emit(\'update:search\', \'hello\')">set search</button>\n' +
+      "  <button data-test=\"set-channel\" @click=\"$emit('update:channel', { uuid: 'ch-1', name: 'WAC 1', channel_type: 'WAC' })\">set channel</button>\n" +
+      '  <button data-test="clear-channel" @click="$emit(\'update:channel\', undefined)">clear channel</button>\n' +
+      '</div>',
   },
   TemplateSelectionList: {
     props: ['page', 'pageSize', 'total'],
@@ -127,6 +133,38 @@ describe('TemplateSelection.vue', () => {
       offset: 0,
       name: '',
       order_by: 'name',
+    });
+  });
+
+  it('updates channel filter and fetches with channel uuid', async () => {
+    const { wrapper, fetchSpy } = mountWithStore();
+    fetchSpy.mockClear();
+
+    await wrapper.find(SELECTOR.filtersSetChannel).trigger('click');
+    expect(fetchSpy).toHaveBeenCalledWith({
+      limit: PAGE_SIZE,
+      offset: 0,
+      name: '',
+      order_by: 'name',
+      channel: 'ch-1',
+    });
+  });
+
+  it('clears channel filter and fetches without channel param', async () => {
+    const { wrapper, fetchSpy } = mountWithStore();
+    fetchSpy.mockClear();
+
+    // set then clear
+    await wrapper.find(SELECTOR.filtersSetChannel).trigger('click');
+    fetchSpy.mockClear();
+    await wrapper.find(SELECTOR.filtersClearChannel).trigger('click');
+
+    expect(fetchSpy).toHaveBeenCalledWith({
+      limit: PAGE_SIZE,
+      offset: 0,
+      name: '',
+      order_by: 'name',
+      channel: undefined,
     });
   });
 

--- a/src/components/NewBroadcast/TemplateSelection/TemplateSelection.vue
+++ b/src/components/NewBroadcast/TemplateSelection/TemplateSelection.vue
@@ -16,7 +16,9 @@
         <TemplateSelectionFilters
           class="template-selection__templates-filters"
           :search="search"
+          :channel="channel"
           @update:search="handleSearchUpdate"
+          @update:channel="handleChannelUpdate"
         />
 
         <TemplateSelectionList
@@ -52,6 +54,7 @@ import TemplateSelectionList from '@/components/NewBroadcast/TemplateSelection/T
 import TemplateSelectionPreview from '@/components/NewBroadcast/TemplateSelection/TemplateSelectionPreview.vue';
 import StepActions from '@/components/NewBroadcast/StepActions.vue';
 import { TemplateStatus } from '@/constants/templates';
+import type { Channel } from '@/types/channel';
 
 const templatesStore = useTemplatesStore();
 const broadcastsStore = useBroadcastsStore();
@@ -59,13 +62,14 @@ const broadcastsStore = useBroadcastsStore();
 const search = ref('');
 const page = ref(1);
 const sort = ref('name');
+const channel = ref<Channel | undefined>(undefined);
 
 onBeforeMount(() => {
   fetchTemplates();
 });
 
 watch(
-  [search, sort],
+  [search, sort, channel],
   useDebounceFn(() => {
     fetchTemplates();
   }, 300),
@@ -104,6 +108,7 @@ const fetchTemplates = () => {
     offset: (page.value - 1) * PAGE_SIZE,
     name: search.value,
     order_by: sort.value,
+    channel: channel.value?.uuid,
   };
 
   templatesStore.fetchTemplates(params);
@@ -112,6 +117,11 @@ const fetchTemplates = () => {
 const handleSearchUpdate = (value: string) => {
   page.value = 1;
   search.value = value;
+};
+
+const handleChannelUpdate = (value: Channel | undefined) => {
+  page.value = 1;
+  channel.value = value;
 };
 
 const handlePageUpdate = (value: number) => {

--- a/src/components/NewBroadcast/TemplateSelection/TemplateSelectionFilters.vue
+++ b/src/components/NewBroadcast/TemplateSelection/TemplateSelectionFilters.vue
@@ -15,6 +15,16 @@
       @update:model-value="handleSearchUpdate"
     />
 
+    <UnnnicSelectSmart
+      v-if="hasMultipleChannels"
+      class="template-selection-filters__channel"
+      :modelValue="channelOption"
+      :options="channelsOptions"
+      :isLoading="loadingChannels"
+      size="sm"
+      @update:model-value="handleChannelUpdate"
+    />
+
     <UnnnicButton
       class="template-selection-filters__new-template"
       size="small"
@@ -30,12 +40,77 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
+import { useProjectStore } from '@/stores/project';
+import type { SelectOption } from '@/types/select';
+import type { Channel } from '@/types/channel';
+
+const projectStore = useProjectStore();
+
+type ChannelOption = SelectOption<string>;
+const ALL_CHANNELS_VALUE = 'ALL';
 
 const props = defineProps<{
   search: string;
+  channel?: Channel;
 }>();
 
-const emit = defineEmits(['update:search']);
+const emit = defineEmits(['update:search', 'update:channel']);
+
+const channels = computed(() => {
+  return projectStore.project.channels.filter(
+    (channel) => channel.channel_type === 'WAC',
+  );
+});
+
+const searchClearIcon = computed(() => {
+  return props.search !== '' ? 'close' : undefined;
+});
+
+const hasMultipleChannels = computed(() => {
+  return channels.value.length > 1;
+});
+
+const loadingChannels = computed(() => {
+  return projectStore.loadingChannels;
+});
+
+const channelsOptions = computed(() => {
+  const channelsOptionsList = channels.value.map((channel) => ({
+    label: channel.name,
+    value: channel.uuid,
+  }));
+
+  const options = [
+    {
+      label: 'All channels',
+      value: ALL_CHANNELS_VALUE,
+    },
+    ...channelsOptionsList,
+  ];
+
+  return options;
+});
+
+const channelOption = computed(() => {
+  if (!props.channel) {
+    return [
+      {
+        label: 'All channels',
+        value: ALL_CHANNELS_VALUE,
+      },
+    ];
+  }
+
+  const option = channelsOptions.value.find(
+    (option) => option.value === props.channel?.uuid,
+  );
+
+  if (!option) {
+    return [];
+  }
+
+  return [option];
+});
 
 const handleSearchUpdate = useDebounceFn((value: string) => {
   emit('update:search', value);
@@ -45,12 +120,21 @@ const handleNewTemplate = () => {
   console.log('new template'); // TODO: Add when integrations is done
 };
 
-const searchClearIcon = computed(() => {
-  return props.search !== '' ? 'close' : undefined;
-});
-
 const handleSearchClear = () => {
   emit('update:search', '');
+};
+
+const handleChannelUpdate = (selectedChannel: ChannelOption[]) => {
+  console.log('handleChannelUpdate', selectedChannel);
+  if (!selectedChannel[0] || selectedChannel[0].value === ALL_CHANNELS_VALUE) {
+    emit('update:channel', undefined);
+    return;
+  }
+
+  const channel = channels.value.find(
+    (channel) => channel.uuid === selectedChannel[0].value,
+  );
+  emit('update:channel', channel);
 };
 </script>
 

--- a/src/components/NewBroadcast/TemplateSelection/TemplateSelectionFilters.vue
+++ b/src/components/NewBroadcast/TemplateSelection/TemplateSelectionFilters.vue
@@ -125,7 +125,6 @@ const handleSearchClear = () => {
 };
 
 const handleChannelUpdate = (selectedChannel: ChannelOption[]) => {
-  console.log('handleChannelUpdate', selectedChannel);
   if (!selectedChannel[0] || selectedChannel[0].value === ALL_CHANNELS_VALUE) {
     emit('update:channel', undefined);
     return;

--- a/src/views/BulkSend/NewBroadcast.vue
+++ b/src/views/BulkSend/NewBroadcast.vue
@@ -61,6 +61,7 @@ const uploadFinished = ref(false);
 onBeforeMount(() => {
   broadcastsStore.setNewBroadcastPage(NewBroadcastPage.SELECT_GROUPS);
   projectStore.getProjectInfo();
+  projectStore.getProjectChannels();
   templatesStore.getTemplatePricing();
 });
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
If a project has more than one whatsapp channel we display a selector to enable channel template filtering

### Summary of Changes
Added select and API changes to enable channel filtering

### Design Files <!--- (If not appropriate, remove this topic) -->
<!--- Links to the design files used for reference during implementation. -->

- [Design File 1](https://www.figma.com/design/oYQwtQhHR0YMbug78GbR3g/Bulk-send?node-id=113-4551&m=dev)

### Demonstration <!--- (If not appropriate, remove this topic) -->
<img width="1263" height="748" alt="image" src="https://github.com/user-attachments/assets/35cfed2e-ef1e-4929-83c0-e14f0f703d4c" />
