### PR TITLE
Feat: new broadcast overflow and buttons text

### DIFF
--- a/src/components/NewBroadcast/ConfirmAndSend/ConfirmAndSend.vue
+++ b/src/components/NewBroadcast/ConfirmAndSend/ConfirmAndSend.vue
@@ -1,142 +1,154 @@
 <!-- eslint-disable vue/no-v-html -->
 <template>
   <section class="confirm-and-send">
-    <h1 class="confirm-and-send__title">
-      {{ $t('new_broadcast.pages.confirm_and_send.title') }}
-    </h1>
+    <section class="confirm-and-send__main">
+      <h1 class="confirm-and-send__title">
+        {{ $t('new_broadcast.pages.confirm_and_send.title') }}
+      </h1>
 
-    <section class="confirm-and-send__content">
-      <section class="confirm-and-send__form">
-        <UnnnicFormElement
-          :label="
-            $t('new_broadcast.pages.confirm_and_send.broadcast_name_label')
-          "
-        >
-          <UnnnicInput
-            :modelValue="broadcastName"
-            :placeholder="
-              $t(
-                'new_broadcast.pages.confirm_and_send.broadcast_name_placeholder',
-              )
+      <section class="confirm-and-send__content">
+        <section class="confirm-and-send__form">
+          <UnnnicFormElement
+            :label="
+              $t('new_broadcast.pages.confirm_and_send.broadcast_name_label')
             "
-            @update:model-value="handleBroadcastNameUpdate"
-          />
-        </UnnnicFormElement>
+          >
+            <UnnnicInput
+              :modelValue="broadcastName"
+              :placeholder="
+                $t(
+                  'new_broadcast.pages.confirm_and_send.broadcast_name_placeholder',
+                )
+              "
+              @update:model-value="handleBroadcastNameUpdate"
+            />
+          </UnnnicFormElement>
 
-        <UnnnicFormElement
-          v-if="projectType === ProjectType.FLOW"
-          :label="$t('new_broadcast.pages.confirm_and_send.flow_label')"
-          :message="$t('new_broadcast.pages.confirm_and_send.flow_message')"
-        >
-          <UnnnicSelectSmart
-            :options="projectFlowsOptions"
-            :modelValue="selectedFlowOption"
-            autocomplete
-            autocompleteClearOnFocus
-            enableSearchByValue
-            :placeholder="
-              $t('new_broadcast.pages.confirm_and_send.flow_placeholder')
+          <UnnnicFormElement
+            v-if="projectType === ProjectType.FLOW"
+            :label="$t('new_broadcast.pages.confirm_and_send.flow_label')"
+            :message="$t('new_broadcast.pages.confirm_and_send.flow_message')"
+          >
+            <UnnnicSelectSmart
+              :options="projectFlowsOptions"
+              :modelValue="selectedFlowOption"
+              autocomplete
+              autocompleteClearOnFocus
+              enableSearchByValue
+              :placeholder="
+                $t('new_broadcast.pages.confirm_and_send.flow_placeholder')
+              "
+              :isLoading="loadingFlows"
+              @update:model-value="handleFlowSelectUpdate"
+            />
+          </UnnnicFormElement>
+          <UnnnicDisclaimer
+            v-else
+            icon="alert-circle-1-1"
+            :text="$t('new_broadcast.pages.confirm_and_send.flow_disclaimer')"
+          />
+
+          <section class="confirm-and-send__info">
+            <ConfirmAndSendAudience class="confirm-and-send__audience" />
+
+            <VariablesSelectionOverview
+              v-if="hasMappedVariable"
+              class="confirm-and-send__variables"
+              :title="
+                $t('new_broadcast.pages.confirm_and_send.variables.title')
+              "
+              :definedVariables="definedVariables"
+            />
+          </section>
+
+          <UnnnicCheckbox
+            :modelValue="reviewed"
+            size="md"
+            :textRight="
+              $t('new_broadcast.pages.confirm_and_send.reviewed_label')
             "
-            :isLoading="loadingFlows"
-            @update:model-value="handleFlowSelectUpdate"
-          />
-        </UnnnicFormElement>
-        <UnnnicDisclaimer
-          v-else
-          icon="alert-circle-1-1"
-          :text="$t('new_broadcast.pages.confirm_and_send.flow_disclaimer')"
-        />
-
-        <section class="confirm-and-send__info">
-          <ConfirmAndSendAudience class="confirm-and-send__audience" />
-
-          <VariablesSelectionOverview
-            v-if="hasMappedVariable"
-            class="confirm-and-send__variables"
-            :title="$t('new_broadcast.pages.confirm_and_send.variables.title')"
-            :definedVariables="definedVariables"
+            @update:model-value="handleReviewedUpdate"
           />
         </section>
 
-        <UnnnicCheckbox
-          :modelValue="reviewed"
-          size="md"
-          :textRight="$t('new_broadcast.pages.confirm_and_send.reviewed_label')"
-          @update:model-value="handleReviewedUpdate"
-        />
+        <TemplateSelectionPreview class="confirm-and-send__preview" />
       </section>
 
-      <TemplateSelectionPreview class="confirm-and-send__preview" />
-    </section>
-
-    <UnnnicModalDialog
-      :modelValue="importNotCompleted"
-      :title="
-        $t('new_broadcast.pages.confirm_and_send.contact_import_pending.title')
-      "
-    >
-      <p class="confirm-and-send__contact-import-pending-content">
-        {{
+      <UnnnicModalDialog
+        :modelValue="importNotCompleted"
+        :title="
           $t(
-            'new_broadcast.pages.confirm_and_send.contact_import_pending.content',
+            'new_broadcast.pages.confirm_and_send.contact_import_pending.title',
           )
-        }}
-      </p>
-    </UnnnicModalDialog>
-
-    <UnnnicModalDialog
-      class="confirm-and-send__broadcast-errored-modal"
-      :modelValue="!!broadcastErrored"
-      :title="
-        $t('new_broadcast.pages.confirm_and_send.broadcast_errored.title')
-      "
-      :primaryButtonProps="{
-        text: $t(
-          'new_broadcast.pages.confirm_and_send.broadcast_errored.primary_button',
-        ),
-      }"
-      hideSecondaryButton
-      showActionsDivider
-      @primary-button-click="handleErrorBack"
-    >
-      <p class="confirm-and-send__broadcast-errored-content">
-        {{
-          $t(
-            'new_broadcast.pages.confirm_and_send.broadcast_errored.description',
-            { error: broadcastErrored?.message },
-          )
-        }}
-      </p>
-    </UnnnicModalDialog>
-
-    <UnnnicModalDialog
-      class="confirm-and-send__broadcast-success-modal"
-      :modelValue="broadcastSuccess"
-      :title="
-        $t('new_broadcast.pages.confirm_and_send.broadcast_success.title')
-      "
-      :primaryButtonProps="{
-        text: $t(
-          'new_broadcast.pages.confirm_and_send.broadcast_success.primary_button',
-        ),
-      }"
-      showActionsDivider
-      hideSecondaryButton
-      @primary-button-click="handleSuccessBack"
-    >
-      <p
-        class="confirm-and-send__broadcast-success-content"
-        v-html="
-          $t('new_broadcast.pages.confirm_and_send.broadcast_success.content', {
-            contact_count: contactCount,
-          })
         "
-      ></p>
-    </UnnnicModalDialog>
+      >
+        <p class="confirm-and-send__contact-import-pending-content">
+          {{
+            $t(
+              'new_broadcast.pages.confirm_and_send.contact_import_pending.content',
+            )
+          }}
+        </p>
+      </UnnnicModalDialog>
+
+      <UnnnicModalDialog
+        class="confirm-and-send__broadcast-errored-modal"
+        :modelValue="!!broadcastErrored"
+        :title="
+          $t('new_broadcast.pages.confirm_and_send.broadcast_errored.title')
+        "
+        :primaryButtonProps="{
+          text: $t(
+            'new_broadcast.pages.confirm_and_send.broadcast_errored.primary_button',
+          ),
+        }"
+        hideSecondaryButton
+        showActionsDivider
+        @primary-button-click="handleErrorBack"
+      >
+        <p class="confirm-and-send__broadcast-errored-content">
+          {{
+            $t(
+              'new_broadcast.pages.confirm_and_send.broadcast_errored.description',
+              { error: broadcastErrored?.message },
+            )
+          }}
+        </p>
+      </UnnnicModalDialog>
+
+      <UnnnicModalDialog
+        class="confirm-and-send__broadcast-success-modal"
+        :modelValue="broadcastSuccess"
+        :title="
+          $t('new_broadcast.pages.confirm_and_send.broadcast_success.title')
+        "
+        :primaryButtonProps="{
+          text: $t(
+            'new_broadcast.pages.confirm_and_send.broadcast_success.primary_button',
+          ),
+        }"
+        showActionsDivider
+        hideSecondaryButton
+        @primary-button-click="handleSuccessBack"
+      >
+        <p
+          class="confirm-and-send__broadcast-success-content"
+          v-html="
+            $t(
+              'new_broadcast.pages.confirm_and_send.broadcast_success.content',
+              {
+                contact_count: contactCount,
+              },
+            )
+          "
+        ></p>
+      </UnnnicModalDialog>
+    </section>
 
     <StepActions
       :disabled="!canContinue"
       :loading="loadingCreateBroadcast"
+      :cancelText="$t('new_broadcast.pages.confirm_and_send.actions.cancel')"
       @cancel="handleCancel"
       @continue="handleContinue"
     />
@@ -437,6 +449,15 @@ const hasIncompleteMapping = (
   flex-direction: column;
   gap: $unnnic-spacing-sm;
   flex: 1;
+  overflow: auto;
+
+  &__main {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-spacing-sm;
+    flex: 1;
+    overflow: auto;
+  }
 
   &__content {
     display: flex;

--- a/src/components/NewBroadcast/GroupSelection/GroupsStep.vue
+++ b/src/components/NewBroadcast/GroupSelection/GroupsStep.vue
@@ -119,6 +119,7 @@ const handleContinue = () => {
   flex-direction: column;
   gap: $unnnic-spacing-sm;
   flex: 1;
+  overflow: auto;
 
   &__group-selection::after {
     content: '';
@@ -133,6 +134,7 @@ const handleContinue = () => {
     display: flex;
     flex-direction: column;
     gap: $unnnic-spacing-sm;
+    overflow: auto;
   }
 }
 </style>

--- a/src/components/NewBroadcast/StepActions.vue
+++ b/src/components/NewBroadcast/StepActions.vue
@@ -6,7 +6,7 @@
       type="tertiary"
       @click="$emit('cancel')"
     >
-      {{ $t('new_broadcast.pages.actions.cancel') }}
+      {{ cancelText || $t('new_broadcast.pages.actions.cancel') }}
     </UnnnicButton>
     <UnnnicButton
       data-test="actions-continue"
@@ -24,6 +24,7 @@
 defineProps<{
   disabled?: boolean;
   loading?: boolean;
+  cancelText?: string;
 }>();
 
 defineEmits<{

--- a/src/components/NewBroadcast/TemplateSelection/TemplateSelection.vue
+++ b/src/components/NewBroadcast/TemplateSelection/TemplateSelection.vue
@@ -1,44 +1,48 @@
 <template>
   <section class="template-selection">
-    <h1 class="template-selection__title">
-      {{ $t('new_broadcast.pages.select_template.page_title') }}
-    </h1>
+    <section class="template-selection__main">
+      <h1 class="template-selection__title">
+        {{ $t('new_broadcast.pages.select_template.page_title') }}
+      </h1>
 
-    <UnnnicDisclaimer
-      class="template-selection__disclaimer"
-      icon="alert-circle-1-1"
-      scheme="neutral-dark"
-      :text="$t('new_broadcast.pages.select_template.disclaimer')"
-    />
+      <UnnnicDisclaimer
+        class="template-selection__disclaimer"
+        icon="alert-circle-1-1"
+        scheme="neutral-dark"
+        :text="$t('new_broadcast.pages.select_template.disclaimer')"
+      />
 
-    <section class="template-selection__content">
-      <section class="template-selection__templates">
-        <TemplateSelectionFilters
-          class="template-selection__templates-filters"
-          :search="search"
-          :channel="channel"
-          @update:search="handleSearchUpdate"
-          @update:channel="handleChannelUpdate"
-        />
+      <section class="template-selection__content">
+        <section class="template-selection__templates">
+          <TemplateSelectionFilters
+            class="template-selection__templates-filters"
+            :search="search"
+            :channel="channel"
+            @update:search="handleSearchUpdate"
+            @update:channel="handleChannelUpdate"
+          />
 
-        <TemplateSelectionList
-          :page="page"
-          :pageSize="PAGE_SIZE"
-          :total="templatesTotal"
-          class="template-selection__templates-list"
-          @update:page="handlePageUpdate"
-          @update:sort="handleSortUpdate"
-        />
+          <TemplateSelectionList
+            :page="page"
+            :pageSize="PAGE_SIZE"
+            :total="templatesTotal"
+            class="template-selection__templates-list"
+            @update:page="handlePageUpdate"
+            @update:sort="handleSortUpdate"
+          />
+        </section>
+
+        <TemplateSelectionPreview class="template-selection__preview" />
       </section>
-
-      <TemplateSelectionPreview class="template-selection__preview" />
     </section>
-
-    <StepActions
-      :disabled="!canContinue"
-      @cancel="handleCancel"
-      @continue="handleContinue"
-    />
+    <footer class="template-selection__footer">
+      <StepActions
+        :disabled="!canContinue"
+        :cancelText="$t('new_broadcast.pages.select_template.actions.cancel')"
+        @cancel="handleCancel"
+        @continue="handleContinue"
+      />
+    </footer>
   </section>
 </template>
 
@@ -143,6 +147,15 @@ const handleSortUpdate = (newSort: { header: string; order: string }) => {
   flex-direction: column;
   gap: $unnnic-spacing-sm;
   flex: 1;
+  overflow: auto;
+
+  &__main {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-spacing-sm;
+    flex: 1;
+    overflow: auto;
+  }
 
   &__title {
     @include unnnic-text-body-lg;

--- a/src/components/NewBroadcast/TemplateSelection/TemplateSelectionPreview.vue
+++ b/src/components/NewBroadcast/TemplateSelection/TemplateSelectionPreview.vue
@@ -97,7 +97,8 @@ const bodyFormatter = (body: string) => {
   border-radius: $unnnic-border-radius-md;
   min-height: 432px; // fixed height as set in the design
   width: 409px; // fixed width as set in the design
-
+  height: fit-content;
+                       
   &__header {
     display: flex;
     padding: $unnnic-spacing-ant $unnnic-spacing-sm;

--- a/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
+++ b/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
@@ -55,6 +55,7 @@
 
     <StepActions
       :disabled="!canContinue"
+      :cancelText="$t('new_broadcast.pages.select_variables.actions.cancel')"
       @cancel="handleCancel"
       @continue="handleContinue"
     />
@@ -203,6 +204,7 @@ const handleContinue = () => {
   flex-direction: column;
   gap: $unnnic-spacing-sm;
   flex: 1;
+  overflow: auto;
 
   &__title {
     @include unnnic-text-body-lg;
@@ -213,6 +215,7 @@ const handleContinue = () => {
   &__content {
     display: flex;
     gap: $unnnic-spacing-sm;
+    overflow: auto;
   }
 
   &__variables-list {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -229,14 +229,20 @@
           "name": "Template preview:",
           "missing": "Choose a template to preview"
         },
-        "disclaimer": "Only templates with an approved status can be selected and sent. Pending templates must wait for Meta’s approval before they can be used. <a target=\"_blank\" href=\"https://developers.facebook.com/docs/whatsapp/message-templates/guidelines/#approval-process\" class=\"highlight\">Learn more in Meta’s documentation</a>"
+        "disclaimer": "Only templates with an approved status can be selected and sent. Pending templates must wait for Meta’s approval before they can be used. <a target=\"_blank\" href=\"https://developers.facebook.com/docs/whatsapp/message-templates/guidelines/#approval-process\" class=\"highlight\">Learn more in Meta’s documentation</a>",
+        "actions": {
+          "cancel": "Back"
+        }
       },
       "select_variables": {
         "title": "Variables",
         "page_title": "Variable mapping",
         "variable_label": "Variable {'{{'}{index}{'}}'}",
         "variable_placeholder": "Select the field that matches this variable",
-        "disclaimer": "Check if each field is correctly mapped, this is how your message will look to each contact."
+        "disclaimer": "Check if each field is correctly mapped, this is how your message will look to each contact.",
+        "actions": {
+          "cancel": "Back"
+        }
       },
       "confirm_and_send": {
         "title": "Review and send",
@@ -275,6 +281,9 @@
           "title": "✅ Send initiated successfully ",
           "content": "Your message is being delivered to {contact_count} contacts, <span class=\"highlight\">this process may take a few minutes to complete</span>.\n\nProgress and results will appear on your home screen as messages are delivered.",
           "primary_button": "Back to home"
+        },
+        "actions": {
+          "cancel": "Back"
         }
       },
       "contact_import": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -228,14 +228,20 @@
           "name": "Vista previa de plantilla:",
           "missing": "Seleccione una plantilla para visualizar"
         },
-        "disclaimer": "Solo se pueden seleccionar y enviar plantillas con estado aprobado. Las plantillas pendientes deben esperar a la aprobación de Meta antes de usarse. <a target=\"_blank\" href=\"https://developers.facebook.com/docs/whatsapp/message-templates/guidelines/#approval-process\" class=\"highlight\">Más información en la documentación de Meta</a>"
+        "disclaimer": "Solo se pueden seleccionar y enviar plantillas con estado aprobado. Las plantillas pendientes deben esperar a la aprobación de Meta antes de usarse. <a target=\"_blank\" href=\"https://developers.facebook.com/docs/whatsapp/message-templates/guidelines/#approval-process\" class=\"highlight\">Más información en la documentación de Meta</a>",
+        "actions": {
+          "cancel": "Volver"
+        }        
       },
       "select_variables": {
         "title": "Variables",
         "page_title": "Mapeo de variables",
         "variable_label": "Variable {'{{'}{index}{'}}'}",
         "variable_placeholder": "Selecciona el campo que coincide con esta variable",
-        "disclaimer": "Revisa si cada campo está correctamente mapeado, este es el aspecto que tendrá tu mensaje para cada contacto."
+        "disclaimer": "Revisa si cada campo está correctamente mapeado, este es el aspecto que tendrá tu mensaje para cada contacto.",
+        "actions": {
+          "cancel": "Volver"
+        }
       },
       "confirm_and_send": {
         "title": "Revisar y enviar",
@@ -274,6 +280,9 @@
           "title": "✅ Envío iniciado con éxito ",
           "content": "Tu mensaje está siendo entregado a {contact_count} contactos, <span class=\"highlight\">este proceso puede tomar unos minutos para completarse</span>.\n\nEl progreso y los resultados aparecerán en tu pantalla de inicio a medida que se entreguen los mensajes.",
           "primary_button": "Volver a la home"
+        },
+        "actions": {
+          "cancel": "Volver"
         }
       },
       "contact_import": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -228,14 +228,20 @@
           "name": "Prévia de modelo:",
           "missing": "Selecione um modelo para visualizar"
         },
-        "disclaimer": "Apenas modelos com status aprovado podem ser selecionados e enviados. Modelos pendentes devem aguardar a aprovação da Meta antes de serem utilizados. <a target=\"_blank\" href=\"https://developers.facebook.com/docs/whatsapp/message-templates/guidelines/#approval-process\" class=\"highlight\">Saiba mais na documentação da Meta</a>"
+        "disclaimer": "Apenas modelos com status aprovado podem ser selecionados e enviados. Modelos pendentes devem aguardar a aprovação da Meta antes de serem utilizados. <a target=\"_blank\" href=\"https://developers.facebook.com/docs/whatsapp/message-templates/guidelines/#approval-process\" class=\"highlight\">Saiba mais na documentação da Meta</a>",
+        "actions": {
+          "cancel": "Voltar"
+        }
       },
       "select_variables": {
         "title": "Variáveis",
         "page_title": "Mapeamento de variáveis",
         "variable_label": "Variável {'{{'}{index}{'}}'}",
         "variable_placeholder": "Selecione o campo que corresponde a esta variável",
-        "disclaimer": "Verifique se cada campo está mapeado corretamente, este é o aspecto que seu mensagem terá para cada contato."
+        "disclaimer": "Verifique se cada campo está mapeado corretamente, este é o aspecto que seu mensagem terá para cada contato.",
+        "actions": {
+          "cancel": "Voltar"
+        }
       },
       "confirm_and_send": {
         "title": "Revisar e enviar",
@@ -274,6 +280,9 @@
           "title": "✅ Envio iniciado com sucesso ",
           "content": "Sua mensagem está sendo entregada a {contact_count} contatos, <span class=\"highlight\">este processo pode levar alguns minutos para ser concluído</span>.\n\nO progresso e os resultados aparecerão na sua tela inicial à medida que as mensagens forem entregues.",
           "primary_button": "Voltar para a home"
+        },
+        "actions": {
+          "cancel": "Voltar"
         }
       },
       "contact_import": {

--- a/src/views/BulkSend/NewBroadcast.vue
+++ b/src/views/BulkSend/NewBroadcast.vue
@@ -102,6 +102,7 @@ const handleBack = () => {
     flex-direction: column;
     gap: $unnnic-spacing-sm;
     flex: 1;
+    overflow: auto;
   }
 
   &__contacts,
@@ -111,6 +112,7 @@ const handleBack = () => {
     display: flex;
     flex-direction: column;
     flex: 1;
+    overflow: auto;
   }
 }
 </style>


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [X] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
New broadcast header and footer buttons should be fixed, only inner content should scroll

### Summary of Changes
Adjusted newbroadcast pages to handle overflow
Changed back buttons text

### Demonstration <!--- (If not appropriate, remove this topic) -->
<img width="1370" height="776" alt="image" src="https://github.com/user-attachments/assets/046be4cd-cd02-4d4b-a0d5-3d29afaba528" />
<img width="1370" height="776" alt="image" src="https://github.com/user-attachments/assets/f1a09854-cb30-4a0e-be53-766aa65e5e1d" />
<img width="1370" height="776" alt="image" src="https://github.com/user-attachments/assets/4e53c91f-dca6-489d-af91-1002a0aca9e5" />
<img width="1370" height="776" alt="image" src="https://github.com/user-attachments/assets/6934d14f-d697-4d31-bef7-5c1d74e14654" />
