### PR TITLE
Fix: template preview page proportion

### DIFF
--- a/src/components/NewBroadcast/ConfirmAndSend/ConfirmAndSend.vue
+++ b/src/components/NewBroadcast/ConfirmAndSend/ConfirmAndSend.vue
@@ -498,6 +498,11 @@ const hasIncompleteMapping = (
     flex-direction: column;
     flex: 1;
     gap: $unnnic-spacing-sm;
+    width: 67%;
+  }
+
+  &__preview {
+    width: 33%;
   }
 
   &__info {

--- a/src/components/NewBroadcast/ConfirmAndSend/ConfirmAndSend.vue
+++ b/src/components/NewBroadcast/ConfirmAndSend/ConfirmAndSend.vue
@@ -483,7 +483,8 @@ const hasIncompleteMapping = (
   }
 
   &__content {
-    display: flex;
+    display: grid;
+    grid-template-columns: 8fr 4fr;
     gap: $unnnic-spacing-sm;
   }
 
@@ -498,11 +499,6 @@ const hasIncompleteMapping = (
     flex-direction: column;
     flex: 1;
     gap: $unnnic-spacing-sm;
-    width: 67%;
-  }
-
-  &__preview {
-    width: 33%;
   }
 
   &__info {

--- a/src/components/NewBroadcast/TemplateSelection/TemplateSelection.vue
+++ b/src/components/NewBroadcast/TemplateSelection/TemplateSelection.vue
@@ -173,20 +173,16 @@ const handleSortUpdate = (newSort: { header: string; order: string }) => {
   }
 
   &__content {
-    display: flex;
+    display: grid;
+    grid-template-columns: 8fr 4fr;
     gap: $unnnic-spacing-sm;
   }
 
   &__templates {
-    width: 67%;
     flex: 1;
     display: flex;
     flex-direction: column;
     gap: $unnnic-spacing-ant;
-  }
-
-  &__preview {
-    width: 33%;
   }
 
   &__disclaimer {

--- a/src/components/NewBroadcast/TemplateSelection/TemplateSelection.vue
+++ b/src/components/NewBroadcast/TemplateSelection/TemplateSelection.vue
@@ -178,10 +178,15 @@ const handleSortUpdate = (newSort: { header: string; order: string }) => {
   }
 
   &__templates {
+    width: 67%;
     flex: 1;
     display: flex;
     flex-direction: column;
     gap: $unnnic-spacing-ant;
+  }
+
+  &__preview {
+    width: 33%;
   }
 
   &__disclaimer {

--- a/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
+++ b/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
@@ -292,12 +292,19 @@ const handleContinue = () => {
     flex-direction: column;
     gap: $unnnic-spacing-sm;
     flex: 1;
+    width: 67%;
+  }
+
+  &__preview {
+    width: 33%;
+    height: fit-content;
   }
 
   &__content {
     display: flex;
     gap: $unnnic-spacing-sm;
     overflow: auto;
+    height: 100%;
   }
 
   &__variables-list {

--- a/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
+++ b/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
@@ -292,16 +292,15 @@ const handleContinue = () => {
     flex-direction: column;
     gap: $unnnic-spacing-sm;
     flex: 1;
-    width: 67%;
   }
 
   &__preview {
-    width: 33%;
     height: fit-content;
   }
 
   &__content {
-    display: flex;
+    display: grid;
+    grid-template-columns: 8fr 4fr;
     gap: $unnnic-spacing-sm;
     overflow: auto;
     height: 100%;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Since preview does not have fixed width anymore, parent components should define the space it will fill

### Summary of Changes
Added 4/12 proportion to template preview in all new broadcast steps