### PR TITLE
fix: prevent header button to be displayed when template does not have a header

### DIFF
--- a/src/__tests__/components/NewBroadcast/VariablesSelection/VariablesSelection.spec.ts
+++ b/src/__tests__/components/NewBroadcast/VariablesSelection/VariablesSelection.spec.ts
@@ -58,6 +58,7 @@ const SELECTOR = {
   disclaimer: '[data-test="disclaimer"]',
   overview: '[data-test="overview"]',
   preview: '[data-test="preview"]',
+  headerMedia: '[data-test="header-media"]',
   actionsCancel: '[data-test="actions-cancel"]',
   actionsContinue: '[data-test="actions-continue"]',
 } as const;
@@ -287,5 +288,25 @@ describe('VariablesSelection.vue', () => {
       .mockImplementation(() => {});
     await wrapper.find(SELECTOR.actionsContinue).trigger('click');
     expect(setPageSpy).toHaveBeenCalledWith(NewBroadcastPage.CONFIRM_AND_SEND);
+  });
+
+  it('does not render header media section when template header is null', async () => {
+    const { wrapper, broadcastsStore } = mountWrapper(0);
+
+    // first, set a media header so the section is rendered
+    broadcastsStore.newBroadcast.selectedTemplate = {
+      variableCount: 0,
+      header: { type: 'IMAGE' },
+    } as any;
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(SELECTOR.headerMedia).exists()).toBe(true);
+
+    // then set header to null and ensure the section (and its button) disappears
+    broadcastsStore.newBroadcast.selectedTemplate = {
+      variableCount: 0,
+      header: null,
+    } as any;
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(SELECTOR.headerMedia).exists()).toBe(false);
   });
 });

--- a/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
+++ b/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
@@ -160,7 +160,10 @@ const variablesToReplace = computed(() => {
 });
 
 const hasMediaHeader = computed(() => {
-  return broadcastsStore.newBroadcast.selectedTemplate?.header?.type !== 'TEXT';
+  return (
+    broadcastsStore.newBroadcast.selectedTemplate?.header &&
+    broadcastsStore.newBroadcast.selectedTemplate?.header.type !== 'TEXT'
+  );
 });
 
 const fetchContactFields = async () => {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [X] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
undefined was being compared with `TEXT`

### Summary of Changes
Updated hasMediaHeader comparison and added tests
