### PR TITLE
feat: Implement idempotency key for createBroadcast functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## [1.9.1] - 2026-05-12
+
 ### Fixed
 - English, Spanish and Portuguese messages
 
 ### Added
 - Romanian messages
+- feat: Implement idempotency key for createBroadcast functionality
 
 ## [1.9.0] - 2026-03-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bulk_send",
-  "version": "1.8.6",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bulk_send",
-      "version": "1.8.6",
+      "version": "1.9.1",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
         "@rspack/cli": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulk_send",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "engines": {
     "node": ">=22.12.0"

--- a/src/__tests__/api/flows/broadcasts.spec.ts
+++ b/src/__tests__/api/flows/broadcasts.spec.ts
@@ -97,6 +97,7 @@ describe('api/resources/flows/broadcasts', () => {
     const variables = ['@fields.name'];
     const groups = ['g1', 'g2'];
     const channel = { uuid: 'ch-1', name: 'WAC 1' } as any;
+    const idempotencyKey = 'idem-1';
 
     // without attachment
     let result = await Broadcasts.createBroadcast(
@@ -105,6 +106,7 @@ describe('api/resources/flows/broadcasts', () => {
       variables,
       groups,
       channel,
+      idempotencyKey,
     );
     expect(httpPost).toHaveBeenCalledWith(
       '/api/v2/internals/whatsapp_broadcasts',
@@ -115,6 +117,7 @@ describe('api/resources/flows/broadcasts', () => {
         msg: { template: { uuid: 'tpl-1', variables, locale: 'en' } },
         groups,
       }),
+      { headers: { 'Idempotency-Key': idempotencyKey } },
     );
     expect(result).toEqual({ data: { id: 99 } });
 
@@ -126,6 +129,7 @@ describe('api/resources/flows/broadcasts', () => {
       variables,
       groups,
       channel,
+      idempotencyKey,
       { url: 'https://cdn/file.jpg', type: 'image' },
     );
     expect(httpPost).toHaveBeenCalledWith(
@@ -136,8 +140,34 @@ describe('api/resources/flows/broadcasts', () => {
           attachments: ['image:https://cdn/file.jpg'],
         },
       }),
+      { headers: { 'Idempotency-Key': idempotencyKey } },
     );
     expect(result).toEqual({ data: { id: 99 } });
+  });
+
+  it('sends Idempotency-Key header on /whatsapp_broadcasts', async () => {
+    const httpPost = vi.fn().mockResolvedValue({ data: { id: 1 } });
+    vi.spyOn(requests as any, '$http', 'get').mockReturnValue({
+      post: httpPost,
+    } as any);
+
+    const template = { uuid: 'tpl-1', language: 'en' } as any;
+    const channel = { uuid: 'ch-1' } as any;
+
+    await Broadcasts.createBroadcast(
+      'BC',
+      template,
+      [],
+      ['g1'],
+      channel,
+      'idem-abc-123',
+    );
+
+    expect(httpPost).toHaveBeenCalledWith(
+      '/api/v2/internals/whatsapp_broadcasts',
+      expect.any(Object),
+      { headers: { 'Idempotency-Key': 'idem-abc-123' } },
+    );
   });
 
   it('calls POST /broadcasts/upload_media with FormData including project_uuid', async () => {

--- a/src/__tests__/components/NewBroadcast/ConfirmAndSend/ConfirmAndSend.spec.ts
+++ b/src/__tests__/components/NewBroadcast/ConfirmAndSend/ConfirmAndSend.spec.ts
@@ -356,7 +356,7 @@ describe('ConfirmAndSend.vue', () => {
 
     expect(createSpy).toHaveBeenCalledTimes(1);
     const args = (createSpy as any).mock.calls[0];
-    expect(args[5]).toEqual({
+    expect(args[6]).toEqual({
       url: 'https://cdn.example.com/file.jpg',
       type: 'image',
     });
@@ -580,6 +580,49 @@ describe('ConfirmAndSend.vue', () => {
 
     expect(createSpy).toHaveBeenCalledTimes(1);
     const args = (createSpy as any).mock.calls[0];
-    expect(args[6]).toEqual(selectedFlow);
+    expect(args[7]).toEqual(selectedFlow);
+  });
+
+  it('rapid concurrent continue clicks dispatch createBroadcast only once', async () => {
+    const { wrapper, broadcastsStore } = mountWrapper();
+    broadcastsStore.setReviewed(true);
+    broadcastsStore.setSelectedFlow({ uuid: 'f1', name: 'Flow 1' } as any);
+    broadcastsStore.setBroadcastName('Once Only');
+    broadcastsStore.setSelectedTemplate({
+      name: 'Tpl',
+      variableCount: 0,
+    } as any);
+    broadcastsStore.setSelectedGroups([{ uuid: 'g1', memberCount: 10 } as any]);
+
+    let resolveCreate: (value?: unknown) => void = () => {};
+    const deferred = new Promise((resolve) => {
+      resolveCreate = resolve;
+    });
+    const createSpy = vi
+      .spyOn(broadcastsStore, 'createBroadcast')
+      .mockReturnValue(deferred as any);
+
+    await wrapper.vm.$nextTick();
+    const continueBtn = wrapper.find(SELECTOR.actionsContinue);
+
+    // Fire three clicks back-to-back without awaiting between them, simulating
+    // a triple-click before Vue has a chance to flip the disabled state.
+    continueBtn.trigger('click');
+    continueBtn.trigger('click');
+    continueBtn.trigger('click');
+
+    // Let the in-flight handleContinue progress past its awaits.
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+
+    resolveCreate(undefined);
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    const successModal = wrapper.findAll(SELECTOR.modal)[2];
+    expect(successModal.attributes('data-open')).toBe('true');
+    expect(createSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/stores/broadcasts.spec.ts
+++ b/src/__tests__/stores/broadcasts.spec.ts
@@ -238,6 +238,7 @@ describe('broadcasts store', () => {
     const attachment = { url: 'https://cdn/x.jpg', type: 'image' };
     const flow = { uuid: 'f1', name: 'Flow 1' } as any;
     const channel = { uuid: 'ch-1', name: 'WAC 1' } as any;
+    const idempotencyKey = 'idem-store-1';
 
     const promise = store.createBroadcast(
       'My Broadcast',
@@ -245,6 +246,7 @@ describe('broadcasts store', () => {
       vars,
       groups,
       channel,
+      idempotencyKey,
       attachment,
       flow,
     );
@@ -257,6 +259,7 @@ describe('broadcasts store', () => {
       vars,
       groups,
       channel,
+      idempotencyKey,
       attachment,
       flow,
     );

--- a/src/api/resources/flows/broadcasts.ts
+++ b/src/api/resources/flows/broadcasts.ts
@@ -50,6 +50,7 @@ export default {
     variables: string[],
     groups: string[],
     channel: Channel,
+    idempotencyKey: string,
     attachment?: { url: string; type: string },
     flow?: FlowReference,
   ) {
@@ -78,9 +79,12 @@ export default {
       data.trigger_flow_uuid = flow.uuid;
     }
 
+    // Per-submission idempotency key lets the backend safely deduplicate this
+    // POST if the same submission is retried (network, proxy, double-click, etc.).
     const response = await request.$http.post(
       `/api/v2/internals/whatsapp_broadcasts`,
       data,
+      { headers: { 'Idempotency-Key': idempotencyKey } },
     );
     return response;
   },

--- a/src/components/NewBroadcast/ConfirmAndSend/composables/useConfirmActions.ts
+++ b/src/components/NewBroadcast/ConfirmAndSend/composables/useConfirmActions.ts
@@ -14,6 +14,15 @@ import { useRouter } from 'vue-router';
 
 type TranslateFn = (key: string, params?: Record<string, unknown>) => string;
 
+const generateIdempotencyKey = (): string => {
+  const cryptoApi = (
+    globalThis as unknown as { crypto?: { randomUUID?: () => string } }
+  ).crypto;
+  if (cryptoApi?.randomUUID) return cryptoApi.randomUUID();
+  // Fallback for environments without crypto.randomUUID (very old browsers/runtimes).
+  return `idem-${Date.now()}-${Math.random().toString(36).slice(2, 12)}`;
+};
+
 export function useConfirmActions(args: {
   t: TranslateFn;
   broadcastsStore: BroadcastsStore;
@@ -25,9 +34,10 @@ export function useConfirmActions(args: {
 
   const broadcastErrored = ref<Error | undefined>(undefined);
   const broadcastSuccess = ref(false);
+  const isSubmitting = ref(false);
 
   const loadingCreateBroadcast = computed(() => {
-    return broadcastsStore.loadingCreateBroadcast;
+    return isSubmitting.value || broadcastsStore.loadingCreateBroadcast;
   });
 
   const canContinue = computed(() => {
@@ -100,6 +110,10 @@ export function useConfirmActions(args: {
   };
 
   const handleContinue = async () => {
+    if (isSubmitting.value) return;
+    isSubmitting.value = true;
+
+    const idempotencyKey = generateIdempotencyKey();
     try {
       const groups = await getSelectedGroups();
       if (!groups || groups.length === 0) {
@@ -159,6 +173,7 @@ export function useConfirmActions(args: {
         variables,
         groups,
         channel,
+        idempotencyKey,
         attachment,
         flow,
       );
@@ -171,6 +186,8 @@ export function useConfirmActions(args: {
           t('new_broadcast.pages.confirm_and_send.unknown_error'),
         );
       }
+    } finally {
+      isSubmitting.value = false;
     }
   };
 

--- a/src/stores/broadcasts.ts
+++ b/src/stores/broadcasts.ts
@@ -123,6 +123,7 @@ export const useBroadcastsStore = defineStore('broadcasts', {
       variables: string[],
       groups: string[],
       channel: Channel,
+      idempotencyKey: string,
       attachment?: { url: string; type: string },
       flow?: FlowReference,
     ) {
@@ -134,6 +135,7 @@ export const useBroadcastsStore = defineStore('broadcasts', {
           variables,
           groups,
           channel,
+          idempotencyKey,
           attachment,
           flow,
         );


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context

A single click on "Continue" in the Confirm and Send step was generating up to three identical `POST /whatsapp_broadcasts` requests, causing the backend to dispatch and bill the broadcast three times. Root cause: `handleContinue` had no synchronous re-entry guard, and `loadingCreateBroadcast` is only flipped deep inside the Pinia action — well after `await getSelectedGroups()` and several validations — so rapid clicks (or any window before Vue flushes the disabled state to the DOM) sneak through and run concurrently.

### Summary of Changes

- **Re-entry guard** in [`src/components/NewBroadcast/ConfirmAndSend/composables/useConfirmActions.ts`](src/components/NewBroadcast/ConfirmAndSend/composables/useConfirmActions.ts): a local `isSubmitting` ref is set synchronously at the top of `handleContinue`; concurrent invocations return immediately. The flag is also OR'd into the exposed `loadingCreateBroadcast` so the button is disabled from the very first click.
- **Idempotency key (defense-in-depth)**: each submission generates a UUID via `crypto.randomUUID()` and threads it through [`broadcastsStore.createBroadcast`](src/stores/broadcasts.ts) → [`BroadcastsAPI.createBroadcast`](src/api/resources/flows/broadcasts.ts) as the `Idempotency-Key` HTTP header. Required at every layer to prevent future regressions.
- **Tests**: triple-click test asserting `createBroadcast` runs exactly once; API test asserting the header is sent. Existing tests updated for the new positional signature.

Backend dedupe lands in https://github.com/weni-ai/flows/pull/786.
