### PR TITLE
feat: Add ICU MessageFormat support for localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.9.2] - 2026-06-18
+
+### Added
+- feat: Add ICU MessageFormat support for localization
+
 ## [1.9.1] - 2026-05-12
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bulk_send",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bulk_send",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
         "@rspack/cli": "^1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "date-fns": "^4.1.0",
         "dotenv": "^17.2.3",
         "html-rspack-plugin": "^6.1.3",
+        "intl-messageformat": "^11.2.8",
         "pinia": "^3.0.3",
         "sass-loader": "^16.0.6",
         "vue": "3.5.11",
@@ -2243,6 +2244,24 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.6.tgz",
+      "integrity": "sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ=="
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.11.tgz",
+      "integrity": "sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.10"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.10.tgz",
+      "integrity": "sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA=="
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -8007,6 +8026,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.8.tgz",
+      "integrity": "sha512-l323RCl3qJDVQ8U9j74ut/hVMdg3VPsOHpVMDvFfz9qiq4dPO5ooVYFNVUzzrpgG39a+RLzcXyJb8VFgIU+tUA==",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.6",
+        "@formatjs/icu-messageformat-parser": "3.5.11"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulk_send",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "private": true,
   "engines": {
     "node": ">=22.12.0"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.3",
     "html-rspack-plugin": "^6.1.3",
+    "intl-messageformat": "^11.2.8",
     "pinia": "^3.0.3",
     "sass-loader": "^16.0.6",
     "vue": "3.5.11",

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -137,6 +137,7 @@ export default defineConfig({
         './locales/pt_br': './src/locales/pt_br.json',
         './locales/en': './src/locales/en.json',
         './locales/es': './src/locales/es.json',
+        './locales/ro': './src/locales/ro.json',
       },
       remotes: {
         connect: `connect@${process.env.MODULE_FEDERATION_CONNECT_URL}/remoteEntry.js`,

--- a/src/__tests__/components/NewBroadcast/VariablesSelection/useVariableLabel.spec.ts
+++ b/src/__tests__/components/NewBroadcast/VariablesSelection/useVariableLabel.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  useVariableLabel,
+  VARIABLE_LABEL_KEY,
+} from '@/components/NewBroadcast/VariablesSelection/composables/useVariableLabel';
+
+const mockT = vi.fn();
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: mockT }),
+}));
+
+describe('useVariableLabel', () => {
+  beforeEach(() => {
+    mockT.mockReset();
+  });
+
+  it('calls t with the variable label key and WhatsApp placeholder format', () => {
+    mockT.mockReturnValue('Variable {{1}}');
+
+    const { getVariableLabel } = useVariableLabel();
+    const result = getVariableLabel(1);
+
+    expect(mockT).toHaveBeenCalledWith(VARIABLE_LABEL_KEY, {
+      placeholder: '{{1}}',
+    });
+    expect(result).toBe('Variable {{1}}');
+  });
+
+  it('uses the provided index in the placeholder', () => {
+    mockT.mockReturnValue('Variable {{3}}');
+
+    const { getVariableLabel } = useVariableLabel();
+    getVariableLabel(3);
+
+    expect(mockT).toHaveBeenCalledWith(VARIABLE_LABEL_KEY, {
+      placeholder: '{{3}}',
+    });
+  });
+});

--- a/src/__tests__/setup/global-mocks.ts
+++ b/src/__tests__/setup/global-mocks.ts
@@ -27,7 +27,8 @@ vi.mock('@/api/requests', () => {
 vi.mock('@/utils/plugins/i18n', () => ({
   default: {
     global: {
-      locale: 'en',
+      locale: { value: 'en' },
+      t: (key: string) => key,
     },
   },
 }));

--- a/src/__tests__/utils/plugins/icuMessageCompiler.spec.ts
+++ b/src/__tests__/utils/plugins/icuMessageCompiler.spec.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { createI18n, type I18nOptions } from 'vue-i18n';
+import {
+  icuMessageCompiler,
+  shouldUseIntlMessageFormat,
+} from '@/utils/plugins/icuMessageCompiler';
+
+function createTestI18n(locale: string, messages: I18nOptions['messages']) {
+  return createI18n({
+    legacy: false,
+    locale,
+    fallbackLocale: 'en',
+    messages,
+    messageCompiler: icuMessageCompiler,
+    warnHtmlInMessage: 'off',
+  });
+}
+
+describe('shouldUseIntlMessageFormat', () => {
+  it('detects ICU plural blocks', () => {
+    expect(
+      shouldUseIntlMessageFormat(
+        '{count, plural, one {# item} other {# items}}',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not false-positive on plain text with comma', () => {
+    expect(shouldUseIntlMessageFormat('{user, select another option}')).toBe(
+      false,
+    );
+    expect(shouldUseIntlMessageFormat('{item, plural forms available}')).toBe(
+      false,
+    );
+  });
+});
+
+describe('icuMessageCompiler', () => {
+  const i18n = createTestI18n('en', {
+    en: {
+      greeting: 'Hello, {name}!',
+      list: 'First: {0}, Second: {1}',
+      html: 'Include a <b class="bold">header row</b> with names',
+      variable_label: 'Variable {placeholder}',
+      plural: '{count, plural, one {{count} contact} other {{count} contacts}}',
+    },
+    ro: {
+      plural:
+        '{count, plural, one {{count} contact} few {{count} contacte} other {{count} contacte}}',
+    },
+  });
+
+  it('resolves plain named interpolation', () => {
+    expect(i18n.global.t('greeting', { name: 'Ana' })).toBe('Hello, Ana!');
+  });
+
+  it('resolves list interpolation for positional placeholders', () => {
+    expect(i18n.global.t('list', ['Alpha', 'Beta'])).toBe(
+      'First: Alpha, Second: Beta',
+    );
+  });
+
+  it('passes HTML through plain messages unchanged', () => {
+    expect(i18n.global.t('html')).toBe(
+      'Include a <b class="bold">header row</b> with names',
+    );
+  });
+
+  it('resolves variable_label placeholder param', () => {
+    expect(i18n.global.t('variable_label', { placeholder: '{{1}}' })).toBe(
+      'Variable {{1}}',
+    );
+  });
+
+  it('resolves ICU plural one/other in English', () => {
+    expect(i18n.global.t('plural', { count: 1 })).toBe('1 contact');
+    expect(i18n.global.t('plural', { count: 5 })).toBe('5 contacts');
+    expect(i18n.global.t('plural', { count: 0 })).toBe('0 contacts');
+  });
+
+  it('resolves ICU plural one/few/other in Romanian', () => {
+    i18n.global.locale.value = 'ro';
+    expect(i18n.global.t('plural', { count: 1 })).toBe('1 contact');
+    expect(i18n.global.t('plural', { count: 2 })).toBe('2 contacte');
+    expect(i18n.global.t('plural', { count: 5 })).toBe('5 contacte');
+    i18n.global.locale.value = 'en';
+  });
+
+  it('keeps unprovided named placeholders literal', () => {
+    expect(i18n.global.t('greeting')).toBe('Hello, {name}!');
+  });
+});
+
+describe('icuMessageCompiler with project locales', () => {
+  it('renders converted group_count plural from locale files', async () => {
+    const en = (await import('@/locales/en.json')).default;
+    const ro = (await import('@/locales/ro.json')).default;
+    const i18n = createTestI18n('en', { en, ro });
+
+    expect(
+      i18n.global.t('new_broadcast.pages.select_groups.group_count', {
+        count: 1,
+      }),
+    ).toBe('1 contact');
+    expect(
+      i18n.global.t('new_broadcast.pages.select_groups.group_count', {
+        count: 3,
+      }),
+    ).toBe('3 contacts');
+
+    i18n.global.locale.value = 'ro';
+    expect(
+      i18n.global.t('new_broadcast.pages.select_groups.group_count', {
+        count: 2,
+      }),
+    ).toBe('2 contacte');
+  });
+});

--- a/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
+++ b/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
@@ -19,7 +19,7 @@
             v-for="index in templateVariablesCount"
             :key="index"
             class="variables-selection__item"
-            :label="variableLabel(index)"
+            :label="getVariableLabel(index)"
           >
             <UnnnicSelectSmart
               :options="contactFields"
@@ -74,6 +74,7 @@ import { useContactStore } from '@/stores/contact';
 import { useBroadcastsStore } from '@/stores/broadcasts';
 import TemplateSelectionPreview from '@/components/NewBroadcast/TemplateSelection/TemplateSelectionPreview.vue';
 import VariablesSelectionOverview from '@/components/NewBroadcast/VariablesSelection/VariablesSelectionOverview.vue';
+import { useVariableLabel } from '@/components/NewBroadcast/VariablesSelection/composables/useVariableLabel';
 import VariablesSelectionHeaderMedia from '@/components/NewBroadcast/VariablesSelection/VariablesSelectionHeaderMedia.vue';
 import { NewBroadcastPage, NAME_FIELD_VALUE } from '@/constants/broadcasts';
 import StepActions from '@/components/NewBroadcast/StepActions.vue';
@@ -86,12 +87,7 @@ import {
 const contactStore = useContactStore();
 const broadcastsStore = useBroadcastsStore();
 const { t } = useI18n();
-
-function variableLabel(index: number) {
-  return t('new_broadcast.pages.select_variables.variable_label', {
-    placeholder: `{{${index}}}`,
-  });
-}
+const { getVariableLabel } = useVariableLabel();
 
 onBeforeMount(() => {
   fetchContactFields();

--- a/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
+++ b/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
@@ -19,11 +19,7 @@
             v-for="index in templateVariablesCount"
             :key="index"
             class="variables-selection__item"
-            :label="
-              $t('new_broadcast.pages.select_variables.variable_label', {
-                index,
-              })
-            "
+            :label="variableLabel(index)"
           >
             <UnnnicSelectSmart
               :options="contactFields"
@@ -90,6 +86,12 @@ import {
 const contactStore = useContactStore();
 const broadcastsStore = useBroadcastsStore();
 const { t } = useI18n();
+
+function variableLabel(index: number) {
+  return t('new_broadcast.pages.select_variables.variable_label', {
+    placeholder: `{{${index}}}`,
+  });
+}
 
 onBeforeMount(() => {
   fetchContactFields();

--- a/src/components/NewBroadcast/VariablesSelection/VariablesSelectionOverview.vue
+++ b/src/components/NewBroadcast/VariablesSelection/VariablesSelectionOverview.vue
@@ -21,11 +21,7 @@
           class="variables-selection-overview__item-label"
           data-test="variables-overview-item-label"
         >
-          {{
-            $t('new_broadcast.pages.select_variables.variable_label', {
-              index: index + 1,
-            })
-          }}
+          {{ variableLabel(index + 1) }}
         </p>
         <UnnnicIcon
           icon="arrow_right_alt"
@@ -43,12 +39,21 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n';
 import type { ContactField } from '@/types/contacts';
+
+const { t } = useI18n();
 
 defineProps<{
   title?: string;
   definedVariables: ContactField[];
 }>();
+
+function variableLabel(index: number) {
+  return t('new_broadcast.pages.select_variables.variable_label', {
+    placeholder: `{{${index}}}`,
+  });
+}
 </script>
 
 <style scoped lang="scss">

--- a/src/components/NewBroadcast/VariablesSelection/VariablesSelectionOverview.vue
+++ b/src/components/NewBroadcast/VariablesSelection/VariablesSelectionOverview.vue
@@ -21,7 +21,7 @@
           class="variables-selection-overview__item-label"
           data-test="variables-overview-item-label"
         >
-          {{ variableLabel(index + 1) }}
+          {{ getVariableLabel(index + 1) }}
         </p>
         <UnnnicIcon
           icon="arrow_right_alt"
@@ -39,21 +39,15 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n';
+import { useVariableLabel } from '@/components/NewBroadcast/VariablesSelection/composables/useVariableLabel';
 import type { ContactField } from '@/types/contacts';
 
-const { t } = useI18n();
+const { getVariableLabel } = useVariableLabel();
 
 defineProps<{
   title?: string;
   definedVariables: ContactField[];
 }>();
-
-function variableLabel(index: number) {
-  return t('new_broadcast.pages.select_variables.variable_label', {
-    placeholder: `{{${index}}}`,
-  });
-}
 </script>
 
 <style scoped lang="scss">

--- a/src/components/NewBroadcast/VariablesSelection/composables/useVariableLabel.ts
+++ b/src/components/NewBroadcast/VariablesSelection/composables/useVariableLabel.ts
@@ -1,0 +1,16 @@
+import { useI18n } from 'vue-i18n';
+
+export const VARIABLE_LABEL_KEY =
+  'new_broadcast.pages.select_variables.variable_label' as const;
+
+export function useVariableLabel() {
+  const { t } = useI18n();
+
+  function getVariableLabel(index: number): string {
+    return t(VARIABLE_LABEL_KEY, {
+      placeholder: `{{${index}}}`,
+    });
+  }
+
+  return { getVariableLabel };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -198,13 +198,13 @@
           }
         },
         "search_placeholder": "Search groups",
-        "group_count": "{count} contacts | {count} contact | {count} contacts",
+        "group_count": "{count, plural, one {{count} contact} other {{count} contacts}}",
         "overview": {
           "cost_value": "{currency}{cost} (cost per message: {currency}{templateMultiplier} per delivered message)",
           "cost_label": "Estimated cost:",
           "total_label": "Total:",
-          "total_value": "{total} selected contacts | {total} selected contact | {total} selected contacts",
-          "title": "{count} selected groups | {count} selected group | {count} selected groups",
+          "total_value": "{total, plural, one {{total} selected contact} other {{total} selected contacts}}",
+          "title": "{count, plural, one {{count} selected group} other {{count} selected groups}}",
           "removal_tooltip": "Remove selected groups"
         },
         "no_groups": "No groups matching your search were found",
@@ -254,7 +254,7 @@
       "select_variables": {
         "title": "Variables",
         "page_title": "Variable mapping",
-        "variable_label": "Variable {'{{'}{index}{'}}'}",
+        "variable_label": "Variable {placeholder}",
         "variable_placeholder": "Select the field that corresponds to this variable",
         "disclaimer": "Make sure each field is mapped correctly. This is how contacts will see your message.",
         "actions": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -198,13 +198,13 @@
           }
         },
         "search_placeholder": "Buscar grupos",
-        "group_count": "{count} contactos | {count} contacto | {count} contactos",
+        "group_count": "{count, plural, one {{count} contacto} other {{count} contactos}}",
         "overview": {
           "cost_value": "{currency}{cost} (costo por mensaje: {currency}{templateMultiplier} por mensaje entregado)",
           "cost_label": "Costo estimado:",
           "total_label": "Total:",
-          "total_value": "{total} contactos seleccionados | {total} contacto seleccionado | {total} contactos seleccionados",
-          "title": "{count} grupos seleccionados | {count} grupo seleccionado | {count} grupos seleccionados",
+          "total_value": "{total, plural, one {{total} contacto seleccionado} other {{total} contactos seleccionados}}",
+          "title": "{count, plural, one {{count} grupo seleccionado} other {{count} grupos seleccionados}}",
           "removal_tooltip": "Remover grupos seleccionados"
         },
         "no_groups": "No se encontraron grupos que coincidan con tu búsqueda",
@@ -254,7 +254,7 @@
       "select_variables": {
         "title": "Variables",
         "page_title": "Mapeo de variables",
-        "variable_label": "Variable {'{{'}{index}{'}}'}",
+        "variable_label": "Variable {placeholder}",
         "variable_placeholder": "Selecciona el campo que corresponde a esta variable",
         "disclaimer": "Asegúrate de que cada campo esté mapeado correctamente. Así es como los contactos verán tu mensaje.",
         "actions": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -198,13 +198,13 @@
           }
         },
         "search_placeholder": "Buscar grupos",
-        "group_count": "{count} contatos | {count} contato | {count} contatos",
+        "group_count": "{count, plural, one {{count} contato} other {{count} contatos}}",
         "overview": {
           "cost_value": "{currency}{cost} (valor unitário: {currency} {templateMultiplier} por mensagem entregue)",
           "cost_label": "Custo estimado:",
           "total_label": "Total:",
-          "total_value": "{total} contatos selecionados | {total} contato selecionado | {total} contatos selecionados",
-          "title": "{count} grupos selecionados | {count} grupo selecionado | {count} grupos selecionados",
+          "total_value": "{total, plural, one {{total} contato selecionado} other {{total} contatos selecionados}}",
+          "title": "{count, plural, one {{count} grupo selecionado} other {{count} grupos selecionados}}",
           "removal_tooltip": "Remover grupos selecionados"
         },
         "no_groups": "Não encontramos nenhum grupo correspondente à sua busca",
@@ -254,7 +254,7 @@
       "select_variables": {
         "title": "Variáveis",
         "page_title": "Mapeamento de variáveis",
-        "variable_label": "Variável {'{{'}{index}{'}}'}",
+        "variable_label": "Variável {placeholder}",
         "variable_placeholder": "Selecione o campo que corresponde a esta variável",
         "disclaimer": "Verifique se cada campo está mapeado corretamente pois será desta forma que o contato irá visualizar sua mensagem",
         "actions": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -198,13 +198,13 @@
                     }
                 },
                 "search_placeholder": "Caută grupuri",
-                "group_count": "{count} contacte | {count} contact | {count} contacte",
+                "group_count": "{count, plural, one {{count} contact} few {{count} contacte} other {{count} contacte}}",
                 "overview": {
                     "cost_value": "{currency}{cost} (cost pe mesaj: {currency}{templateMultiplier} pe mesaj livrat)",
                     "cost_label": "Cost estimat:",
                     "total_label": "Total:",
-                    "total_value": "{total} contacte selectate | {total} contact selectat | {total} contacte selectate",
-                    "title": "{count} grupuri selectate | {count} grup selectat | {count} grupuri selectate",
+                    "total_value": "{total, plural, one {{total} contact selectat} few {{total} contacte selectate} other {{total} contacte selectate}}",
+                    "title": "{count, plural, one {{count} grup selectat} few {{count} grupuri selectate} other {{count} grupuri selectate}}",
                     "removal_tooltip": "Elimină grupurile selectate"
                 },
                 "no_groups": "Nu au fost găsite grupuri care să corespundă căutării tale",
@@ -254,7 +254,7 @@
             "select_variables": {
                 "title": "Variabile",
                 "page_title": "Maparea variabilelor",
-                "variable_label": "Variabilă {'{{'}{index}{'}}'}",
+                "variable_label": "Variabilă {placeholder}",
                 "variable_placeholder": "Selectează câmpul care corespunde acestei variabile",
                 "disclaimer": "Asigură-te că fiecare câmp este mapat corect. În acest mod, persoanele tale de contact îți vor vedea mesajul.",
                 "actions": {

--- a/src/utils/plugins/i18n.ts
+++ b/src/utils/plugins/i18n.ts
@@ -3,11 +3,14 @@ import { createI18n } from 'vue-i18n';
 import pt_br from '@/locales/pt_br.json';
 import en from '@/locales/en.json';
 import es from '@/locales/es.json';
+import ro from '@/locales/ro.json';
+import { icuMessageCompiler } from '@/utils/plugins/icuMessageCompiler';
 
 const languages = {
   'pt-br': pt_br,
   en,
   es,
+  ro,
 };
 
 const messages = Object.assign(languages);
@@ -17,6 +20,8 @@ export default createI18n({
   locale: 'en',
   fallbackLocale: 'en',
   messages,
+  messageCompiler: icuMessageCompiler,
+  warnHtmlInMessage: 'off',
   silentTranslationWarn: true,
   silentFallbackWarn: true,
 });

--- a/src/utils/plugins/icuMessageCompiler.ts
+++ b/src/utils/plugins/icuMessageCompiler.ts
@@ -1,0 +1,148 @@
+import IntlMessageFormat from 'intl-messageformat';
+import type { CompileError, MessageCompiler, MessageContext } from 'vue-i18n';
+
+type NamedValues = Record<string, unknown>;
+
+/**
+ * `interpolate` and `normalize` exist on the runtime message context but are
+ * excluded from the public type. They are required so a single message function
+ * works both for `t()` (text) and the `<i18n-t>` component (vnode).
+ */
+type RuntimeMessageContext = MessageContext & {
+  interpolate: (_value: unknown) => unknown;
+  normalize: (_values: unknown[]) => unknown;
+};
+
+/**
+ * Matches real ICU blocks only: {var, plural|selectordinal, <branch> { … }
+ * or {var, select, <key> { … }. Avoids false positives like
+ * "{user, select another option}" or "{item, plural forms available}".
+ */
+const ICU_PLURAL_OR_SELECTORDINAL_PATTERN =
+  /\{([a-zA-Z][\w]*),\s*(?:plural|selectordinal)\s*,\s*(?:(?:=\d+)|zero|one|two|few|many|other)\s*\{/i;
+
+const ICU_SELECT_PATTERN = /\{([a-zA-Z][\w]*),\s*select\s*,\s*[\w#.-]+\s*\{/i;
+
+export function shouldUseIntlMessageFormat(message: string): boolean {
+  return (
+    ICU_PLURAL_OR_SELECTORDINAL_PATTERN.test(message) ||
+    ICU_SELECT_PATTERN.test(message)
+  );
+}
+
+/** Tag names in ICU XML markup (<b>, <i>, <br/>) need function handlers in .format(). */
+const ICU_XML_TAG_PATTERN = /<\/?([a-zA-Z][a-zA-Z0-9]*)\b/g;
+
+const NAMED_PLACEHOLDER_PATTERN = /\{(\w+)\}/g;
+
+/**
+ * Builds the message parts for plain (non-ICU) strings, resolving `{name}`
+ * placeholders through the message context. Unprovided placeholders are kept
+ * literally to preserve the previous behavior. Returning context-resolved parts
+ * lets `ctx.normalize` produce a string for `t()` and vnodes for `<i18n-t>`.
+ */
+function buildPlainMessageParts(
+  message: string,
+  ctx: RuntimeMessageContext,
+): unknown[] {
+  const values = (ctx.values || {}) as NamedValues;
+  const parts: unknown[] = [];
+  let lastIndex = 0;
+  let match;
+
+  NAMED_PLACEHOLDER_PATTERN.lastIndex = 0;
+  while ((match = NAMED_PLACEHOLDER_PATTERN.exec(message)) !== null) {
+    const [token, name] = match;
+
+    if (match.index > lastIndex) {
+      parts.push(message.slice(lastIndex, match.index));
+    }
+
+    if (/^\d+$/.test(name)) {
+      parts.push(ctx.interpolate(ctx.list(Number(name))));
+    } else if (Object.prototype.hasOwnProperty.call(values, name)) {
+      parts.push(ctx.interpolate(ctx.named(name)));
+    } else {
+      parts.push(token);
+    }
+
+    lastIndex = NAMED_PLACEHOLDER_PATTERN.lastIndex;
+  }
+
+  if (lastIndex < message.length) {
+    parts.push(message.slice(lastIndex));
+  }
+
+  return parts;
+}
+
+function createDefaultTagHandler(tagName: string) {
+  if (tagName === 'br') {
+    return (chunks: string[]) => chunks.join('') + '<br/>';
+  }
+
+  return (chunks: string[]) => {
+    const content = chunks.join('');
+    return `<${tagName}>${content}</${tagName}>`;
+  };
+}
+
+/**
+ * Merges $t params with default ICU tag handlers so plural + HTML works without
+ * passing b/i/br manually on every call.
+ */
+function buildIntlFormatValues(
+  message: string,
+  values: NamedValues = {},
+): NamedValues {
+  const formatValues: NamedValues = { ...(values || {}) };
+  let match;
+
+  while ((match = ICU_XML_TAG_PATTERN.exec(message)) !== null) {
+    const tagName = match[1];
+    const existing = formatValues[tagName];
+
+    if (typeof existing === 'function') {
+      continue;
+    }
+
+    formatValues[tagName] = createDefaultTagHandler(tagName);
+  }
+
+  ICU_XML_TAG_PATTERN.lastIndex = 0;
+  return formatValues;
+}
+
+/**
+ * Vue I18n custom messageCompiler: ICU plural/select via IntlMessageFormat;
+ * plain strings (HTML, simple {name}, list {0}) use named/list interpolation.
+ * Both branches return through `ctx.normalize` so the same compiled function
+ * supports `t()` (string output) and `<i18n-t>` (vnode array output).
+ */
+export const icuMessageCompiler: MessageCompiler = (
+  message,
+  { locale, key, onError },
+) => {
+  if (typeof message === 'string') {
+    if (shouldUseIntlMessageFormat(message)) {
+      const formatter = new IntlMessageFormat(message, locale);
+      return (context: MessageContext) => {
+        const ctx = context as RuntimeMessageContext;
+        const formatted = formatter.format(
+          buildIntlFormatValues(message, ctx.values as NamedValues),
+        );
+        const parts = Array.isArray(formatted) ? formatted : [formatted];
+        return ctx.normalize(parts) as string;
+      };
+    }
+
+    return (context: MessageContext) => {
+      const ctx = context as RuntimeMessageContext;
+      return ctx.normalize(buildPlainMessageParts(message, ctx)) as string;
+    };
+  }
+
+  const astError = new Error('not support for AST') as unknown as CompileError;
+  onError?.(astError);
+  return () => key;
+};


### PR DESCRIPTION
## What
- Adds ICU MessageFormat support via `intl-messageformat` and a custom `icuMessageCompiler` registered on vue-i18n
- Converts pipe-plural locale strings to ICU format in `en`, `pt_br`, `es`, and `ro`
- Wires Romanian (`ro`) into i18n and Module Federation locale exposes
- Updates variable label rendering to pass WhatsApp template placeholders via a `{placeholder}` param

## Why
VTEX localization delivers plural strings in ICU format. The app still used vue-i18n pipe syntax, which breaks plural rendering when new translations are merged from the localization workflow.

## Test plan
- [x] Group selection shows correct singular/plural for `group_count` and overview title/total
- [x] Confirm & send details render `<I18nT>` list slots (`{0}`, `{1}`) correctly
- [x] Variables step shows labels like `Variable {{1}}`
- [x] Broadcast success modal and contact import instructions still render HTML highlights
- [x] `npm run test:coverage`
- [x] `npm run type-check`

Made with [Cursor](https://cursor.com)