### PR TITLE
⚙️ Migrate deprecated `UnnnicSelectSmart` to `UnnnicSelect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.11.0] - 2026-07-14
+
+### Changed
+- refactor: migrate deprecated `UnnnicSelectSmart` to `UnnnicSelect`
+
 ## [1.10.0] - 2026-06-30
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bulk_send",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bulk_send",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
         "@rspack/cli": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bulk_send",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "engines": {
     "node": ">=22.12.0"

--- a/src/__tests__/components/NewBroadcast/ConfirmAndSend/ConfirmAndSend.spec.ts
+++ b/src/__tests__/components/NewBroadcast/ConfirmAndSend/ConfirmAndSend.spec.ts
@@ -27,9 +27,9 @@ const STUBS = {
     template:
       '<input data-test="name-input" :value="modelValue" @input="$emit(\'update:model-value\', $event.target.value)" />',
   },
-  UnnnicSelectSmart: {
-    props: ['options', 'modelValue', 'isLoading', 'placeholder'],
-    emits: ['update:model-value'],
+  UnnnicSelect: {
+    props: ['options', 'modelValue', 'disabled', 'placeholder', 'returnObject'],
+    emits: ['update:model-value', 'update:search'],
     template: '<select data-test="flow-select"></select>',
   },
   UnnnicDisclaimer: {
@@ -154,7 +154,7 @@ describe('ConfirmAndSend.vue', () => {
   it('emits selection to set selected flow in store', async () => {
     const { wrapper, broadcastsStore, flowsStore } = mountWrapper();
     const select = wrapper.find(SELECTOR.flowSelect);
-    const option = [{ label: 'Flow 2', value: 'f2' }];
+    const option = { label: 'Flow 2', value: 'f2' };
     // Emit update:model-value as the component would
     await select.trigger('change');
     // Directly call handler via component instance (simulate event)

--- a/src/__tests__/components/NewBroadcast/ContactImport/ContactImportProcessingForm.spec.ts
+++ b/src/__tests__/components/NewBroadcast/ContactImport/ContactImportProcessingForm.spec.ts
@@ -23,20 +23,20 @@ const STUBS = {
     template:
       '<input data-test="group-name" :value="modelValue" @input="$emit(\'update:model-value\', $event.target.value)" />',
   },
-  UnnnicSelectSmart: {
-    name: 'UnnnicSelectSmart',
+  UnnnicSelect: {
+    name: 'UnnnicSelect',
     props: [
       'modelValue',
       'options',
-      'isLoading',
+      'disabled',
       'size',
-      'autocomplete',
-      'autocompleteClearOnFocus',
-      'autocompleteIconLeft',
+      'enableSearch',
+      'search',
+      'returnObject',
     ],
-    emits: ['update:model-value'],
+    emits: ['update:model-value', 'update:search'],
     template:
-      '<select data-test="group-select" @change="$emit(\'update:model-value\', [options.find(o => o.value == $event.target.value)])"><option v-for="opt in options" :key="opt.value" :value="opt.value">{{ opt.label }}</option></select>',
+      '<select data-test="group-select" @change="$emit(\'update:model-value\', options.find(o => o.value == $event.target.value))"><option v-for="opt in options" :key="opt.value" :value="opt.value">{{ opt.label }}</option></select>',
   },
 } as const;
 

--- a/src/__tests__/components/NewBroadcast/ContactImport/ContactImportProcessingMapping.spec.ts
+++ b/src/__tests__/components/NewBroadcast/ContactImport/ContactImportProcessingMapping.spec.ts
@@ -24,9 +24,9 @@ const STUBS = {
     template:
       '<button data-test="checkbox" :data-disabled="disabled" :data-checked="modelValue" @click="$emit(\'update:model-value\', !modelValue)">cb</button>',
   },
-  UnnnicSelectSmart: {
-    name: 'UnnnicSelectSmart',
-    props: ['options', 'modelValue', 'size'],
+  UnnnicSelect: {
+    name: 'UnnnicSelect',
+    props: ['options', 'modelValue', 'size', 'returnObject'],
     emits: ['update:model-value'],
     template: '<div data-test="select"></div>',
   },
@@ -123,10 +123,11 @@ describe('ContactImportProcessingMapping.vue', () => {
     ).toBe('age');
 
     // Change type via select component emit
-    const select = rows[2].findComponent({ name: 'UnnnicSelectSmart' });
-    select.vm.$emit('update:model-value', [
-      { label: 'Date', value: ContactFieldType.DATE },
-    ]);
+    const select = rows[2].findComponent({ name: 'UnnnicSelect' });
+    select.vm.$emit('update:model-value', {
+      label: 'Date',
+      value: ContactFieldType.DATE,
+    });
     await wrapper.vm.$nextTick();
 
     expect(

--- a/src/__tests__/components/NewBroadcast/TemplateSelection/TemplateSelectionFilters.spec.ts
+++ b/src/__tests__/components/NewBroadcast/TemplateSelection/TemplateSelectionFilters.spec.ts
@@ -13,8 +13,6 @@ vi.mock('@vueuse/core', () => ({ useDebounceFn: (fn: any) => fn }));
 const SELECTOR = {
   search: '[data-test="search"]',
   newTemplate: '[data-test="new-template"]',
-  setChannel: '[data-test="set-channel"]',
-  clearChannel: '[data-test="clear-channel"]',
 } as const;
 
 const stubs = {
@@ -35,12 +33,6 @@ const stubs = {
     props: ['size', 'type', 'iconLeft', 'text'],
     template:
       '<button data-test="new-template" @click="$emit(\'click\')">new</button>',
-  },
-  UnnnicSelectSmart: {
-    props: ['modelValue', 'options', 'isLoading', 'size'],
-    emits: ['update:model-value'],
-    template:
-      '<div data-test="channel"><button data-test="set-channel" @click="$emit(\'update:model-value\', [{ label: \'WAC 1\', value: \'ch-1\' }])">set</button><button data-test="clear-channel" @click="$emit(\'update:model-value\', [])">clear</button></div>',
   },
 } as const;
 

--- a/src/__tests__/components/NewBroadcast/VariablesSelection/VariablesSelection.spec.ts
+++ b/src/__tests__/components/NewBroadcast/VariablesSelection/VariablesSelection.spec.ts
@@ -15,17 +15,17 @@ const STUBS = {
     props: ['label'],
     template: '<div data-test="form-element"><slot /></div>',
   },
-  UnnnicSelectSmart: {
+  UnnnicSelect: {
     props: [
       'options',
       'modelValue',
       'placeholder',
-      'isLoading',
-      'autocomplete',
-      'autocompleteClearOnFocus',
-      'enableSearchByValue',
+      'disabled',
+      'enableSearch',
+      'search',
+      'returnObject',
     ],
-    emits: ['update:model-value'],
+    emits: ['update:model-value', 'update:search'],
     template: '<select data-test="variable-select"></select>',
   },
   UnnnicDisclaimer: {
@@ -157,9 +157,10 @@ describe('VariablesSelection.vue', () => {
   it('maps NAME_FIELD_VALUE to name field with translated label', async () => {
     const { wrapper, broadcastsStore } = mountWrapper(1);
     // simulate selection of the special name field option
-    await (wrapper.vm as any).handleVariableUpdate(0, [
-      { label: 'ignored', value: NAME_FIELD_VALUE },
-    ]);
+    await (wrapper.vm as any).handleVariableUpdate(0, {
+      label: 'ignored',
+      value: NAME_FIELD_VALUE,
+    });
 
     const mapped = broadcastsStore.newBroadcast.variableMapping[0] as any;
     expect(mapped.key).toBe(NAME_FIELD_VALUE);
@@ -178,9 +179,10 @@ describe('VariablesSelection.vue', () => {
     const spy = vi.spyOn(broadcastsStore, 'updateVariableMapping');
     spy.mockClear();
 
-    await (wrapper.vm as any).handleVariableUpdate(0, [
-      { label: 'Age', value: 'age' },
-    ]);
+    await (wrapper.vm as any).handleVariableUpdate(0, {
+      label: 'Age',
+      value: 'age',
+    });
 
     expect(spy).not.toHaveBeenCalled();
   });

--- a/src/__tests__/components/modals/ChannelSelectionModal.spec.ts
+++ b/src/__tests__/components/modals/ChannelSelectionModal.spec.ts
@@ -42,15 +42,9 @@ describe('components/modals/ChannelSelectionModal', () => {
             ],
             template: '<div><slot /></div>',
           },
-          UnnnicSelectSmart: {
-            name: 'UnnnicSelectSmart',
-            props: [
-              'options',
-              'modelValue',
-              'isLoading',
-              'orderedByIndex',
-              'selectFirst',
-            ],
+          UnnnicSelect: {
+            name: 'UnnnicSelect',
+            props: ['options', 'modelValue', 'disabled', 'returnObject'],
             emits: ['update:model-value'],
             template: '<select />',
           },
@@ -69,7 +63,7 @@ describe('components/modals/ChannelSelectionModal', () => {
     ];
 
     const wrapper = mountModal();
-    const select = wrapper.findComponent({ name: 'UnnnicSelectSmart' });
+    const select = wrapper.findComponent({ name: 'UnnnicSelect' });
     const options = select.props('options') as Array<{
       label: string;
       value: string;
@@ -88,10 +82,8 @@ describe('components/modals/ChannelSelectionModal', () => {
     broadcastsStore.setChannel(ch);
 
     const wrapper = mountModal();
-    const select = wrapper.findComponent({ name: 'UnnnicSelectSmart' });
-    expect(select.props('modelValue')).toEqual([
-      { label: 'Chosen', value: 'z' },
-    ]);
+    const select = wrapper.findComponent({ name: 'UnnnicSelect' });
+    expect(select.props('modelValue')).toEqual({ label: 'Chosen', value: 'z' });
   });
 
   it('emits update:modelValue when modal value changes', async () => {
@@ -109,8 +101,8 @@ describe('components/modals/ChannelSelectionModal', () => {
 
     const wrapper = mountModal();
 
-    const select = wrapper.findComponent({ name: 'UnnnicSelectSmart' });
-    await select.vm.$emit('update:model-value', [{ label: 'X', value: 'x' }]);
+    const select = wrapper.findComponent({ name: 'UnnnicSelect' });
+    await select.vm.$emit('update:model-value', { label: 'X', value: 'x' });
 
     expect(broadcastsStore.newBroadcast.channel).toEqual(ch);
 

--- a/src/components/NewBroadcast/ConfirmAndSend/composables/useFlowSelection.ts
+++ b/src/components/NewBroadcast/ConfirmAndSend/composables/useFlowSelection.ts
@@ -21,23 +21,20 @@ export function useFlowSelection(
     }));
   });
 
-  const selectedFlowOption = computed<FlowOption[]>(() => {
+  const selectedFlowOption = computed<FlowOption | undefined>(() => {
     if (!broadcastsStore.newBroadcast.selectedFlow) {
-      return [];
+      return undefined;
     }
 
-    return [
-      {
-        label: broadcastsStore.newBroadcast.selectedFlow.name,
-        value: broadcastsStore.newBroadcast.selectedFlow.uuid,
-      },
-    ];
+    return {
+      label: broadcastsStore.newBroadcast.selectedFlow.name,
+      value: broadcastsStore.newBroadcast.selectedFlow.uuid,
+    };
   });
 
-  const handleFlowSelectUpdate = (selection: FlowOption[]) => {
-    const flowUuid = selection[0].value;
+  const handleFlowSelectUpdate = (selection: FlowOption) => {
     const flow = flowsStore.flows.find(
-      (flow: FlowReference) => flow.uuid === flowUuid,
+      (flow: FlowReference) => flow.uuid === selection.value,
     );
     broadcastsStore.setSelectedFlow(flow);
   };

--- a/src/components/NewBroadcast/ConfirmAndSend/parts/ConfirmForm.vue
+++ b/src/components/NewBroadcast/ConfirmAndSend/parts/ConfirmForm.vue
@@ -17,16 +17,17 @@
       :label="$t('new_broadcast.pages.confirm_and_send.flow_label')"
       :message="$t('new_broadcast.pages.confirm_and_send.flow_message')"
     >
-      <UnnnicSelectSmart
+      <UnnnicSelect
+        returnObject
         :options="projectFlowsOptions"
         :modelValue="selectedFlowOption"
-        autocomplete
-        autocompleteClearOnFocus
-        enableSearchByValue
+        enableSearch
+        :search="flowSearch"
+        :disabled="loadingFlows"
         :placeholder="
           $t('new_broadcast.pages.confirm_and_send.flow_placeholder')
         "
-        :isLoading="loadingFlows"
+        @update:search="flowSearch = $event"
         @update:model-value="onFlowSelectUpdate"
       />
     </UnnnicFormElement>
@@ -40,6 +41,7 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { ProjectType } from '@/constants/project';
 import type { SelectOption } from '@/types/select';
@@ -50,11 +52,13 @@ defineProps<{
   broadcastName: string;
   projectType: ProjectType;
   projectFlowsOptions: FlowOption[];
-  selectedFlowOption: FlowOption[];
+  selectedFlowOption: FlowOption | undefined;
   loadingFlows: boolean;
   onBroadcastNameUpdate: (value: string) => void;
-  onFlowSelectUpdate: (selection: FlowOption[]) => void;
+  onFlowSelectUpdate: (selection: FlowOption) => void;
 }>();
+
+const flowSearch = ref('');
 
 useI18n();
 </script>

--- a/src/components/NewBroadcast/ContactImport/ContactImportProcessingForm.vue
+++ b/src/components/NewBroadcast/ContactImport/ContactImportProcessingForm.vue
@@ -51,14 +51,15 @@
             )
           }}
         </label>
-        <UnnnicSelectSmart
+        <UnnnicSelect
+          returnObject
           :modelValue="groupOption"
           :options="groups"
-          :isLoading="loadingGroups"
+          :disabled="loadingGroups"
           size="sm"
-          autocomplete
-          autocompleteClearOnFocus
-          autocompleteIconLeft
+          enableSearch
+          :search="groupSearch"
+          @update:search="groupSearch = $event"
           @update:model-value="handleGroupSelectUpdate"
         />
       </section>
@@ -100,17 +101,17 @@ const ActionType: Record<string, string> = {
 const actionType = ref(ActionType.CREATE);
 const actionTypeOptions = Object.values(ActionType);
 
-const groupOption = computed<SelectOption[]>(() => {
+const groupSearch = ref('');
+
+const groupOption = computed<SelectOption | undefined>(() => {
   if (group.value) {
-    return [
-      {
-        label: group.value.name,
-        value: group.value.id.toString(),
-      },
-    ];
+    return {
+      label: group.value.name,
+      value: group.value.id.toString(),
+    };
   }
 
-  return [];
+  return undefined;
 });
 
 const groups = computed<SelectOption[]>(() => {
@@ -131,7 +132,7 @@ const groups = computed<SelectOption[]>(() => {
 });
 
 const clearAll = () => {
-  handleGroupSelectUpdate([]);
+  handleGroupSelectUpdate(undefined);
   handleGroupNameUpdate('');
 };
 
@@ -157,13 +158,13 @@ const handleGroupNameUpdate = (value: string) => {
   contactImportStore.setProcessingGroupName(value);
 };
 
-const handleGroupSelectUpdate = (value: SelectOption[]) => {
-  if (value.length === 0) {
+const handleGroupSelectUpdate = (value: SelectOption | undefined) => {
+  if (!value || value.value === '') {
     contactImportStore.setProcessingGroup(undefined);
     return;
   }
 
-  const selectedGroup = value[0];
+  const selectedGroup = value;
   const group = groupsStore.groups.find(
     (group) => group.id === Number(selectedGroup.value),
   );

--- a/src/components/NewBroadcast/ContactImport/ContactImportProcessingMapping.vue
+++ b/src/components/NewBroadcast/ContactImport/ContactImportProcessingMapping.vue
@@ -34,13 +34,14 @@
         <p v-if="item.columnType !== ContactImportColumnType.NEW_FIELD">
           {{ itemTypeLabel(item.type) }}
         </p>
-        <UnnnicSelectSmart
+        <UnnnicSelect
           v-else
+          returnObject
           :options="fieldTypeOptions"
           :modelValue="getFieldTypeOption(item)"
           size="sm"
           @update:model-value="
-            (event: SelectOption<ContactFieldType>[]) =>
+            (event: SelectOption<ContactFieldType>) =>
               handleFieldTypeUpdate(item, event)
           "
         />
@@ -236,14 +237,15 @@ const handleSelect = (item: Row) => {
 
 const handleFieldTypeUpdate = (
   item: Row,
-  options: SelectOption<ContactFieldType>[],
+  option: SelectOption<ContactFieldType>,
 ) => {
-  item.type = options[0].value;
+  item.type = option.value;
 };
 
-const getFieldTypeOption = (item: Row): SelectOption<ContactFieldType>[] => {
-  const option = fieldTypeOptions.find((option) => option.value === item.type);
-  return [option!];
+const getFieldTypeOption = (
+  item: Row,
+): SelectOption<ContactFieldType> | undefined => {
+  return fieldTypeOptions.find((option) => option.value === item.type);
 };
 </script>
 

--- a/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
+++ b/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
@@ -21,20 +21,19 @@
             class="variables-selection__item"
             :label="getVariableLabel(index)"
           >
-            <UnnnicSelectSmart
+            <UnnnicSelect
+              returnObject
               :options="contactFields"
               :modelValue="variableOption(index - 1)"
-              autocomplete
-              autocompleteClearOnFocus
-              enableSearchByValue
-              orderedByIndex
-              :selectFirst="false"
-              :isLoading="loadingContactFields"
+              enableSearch
+              :search="variableSearch"
+              :disabled="loadingContactFields"
               :placeholder="
                 $t('new_broadcast.pages.select_variables.variable_placeholder')
               "
+              @update:search="variableSearch = $event"
               @update:model-value="
-                (event: ContactFieldOption[]) =>
+                (event: ContactFieldOption | undefined) =>
                   handleVariableUpdate(index - 1, event)
               "
             />
@@ -68,7 +67,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeMount, computed } from 'vue';
+import { onBeforeMount, computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useContactStore } from '@/stores/contact';
 import { useBroadcastsStore } from '@/stores/broadcasts';
@@ -97,6 +96,8 @@ const nameFieldOption: ContactFieldOption = {
   label: t('new_broadcast.pages.select_variables.name_field_label'),
   value: NAME_FIELD_VALUE,
 };
+
+const variableSearch = ref('');
 
 const contactFields = computed(() => {
   const fields = contactStore.contactFields.map(
@@ -171,19 +172,22 @@ const initializeVariableMapping = () => {
   }
 };
 
-const handleVariableUpdate = (key: number, newValue: ContactFieldOption[]) => {
-  if (!newValue || newValue.length === 0) {
+const handleVariableUpdate = (
+  key: number,
+  newValue: ContactFieldOption | undefined,
+) => {
+  if (!newValue) {
     broadcastsStore.updateVariableMapping(key, undefined);
     return;
   }
 
   // check if the value is the same as the old value
   const oldValue = variableMapping.value[key];
-  if (oldValue?.key === newValue[0].value) {
+  if (oldValue?.key === newValue.value) {
     return;
   }
 
-  const newFieldKey = newValue[0];
+  const newFieldKey = newValue;
 
   if (newFieldKey.value === NAME_FIELD_VALUE) {
     const nameField: ContactField = {
@@ -203,19 +207,17 @@ const handleVariableUpdate = (key: number, newValue: ContactFieldOption[]) => {
   broadcastsStore.updateVariableMapping(key, field);
 };
 
-const variableOption = (index: number): ContactFieldOption[] => {
+const variableOption = (index: number): ContactFieldOption | undefined => {
   const mapping = broadcastsStore.newBroadcast.variableMapping;
 
   if (!mapping[index]) {
-    return [];
+    return undefined;
   }
 
-  return [
-    {
-      label: mapping[index].label,
-      value: mapping[index].key,
-    },
-  ];
+  return {
+    label: mapping[index].label,
+    value: mapping[index].key,
+  };
 };
 
 const hasFilledVariables = computed(() => {

--- a/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
+++ b/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
@@ -26,12 +26,12 @@
               :options="contactFields"
               :modelValue="variableOption(index - 1)"
               enableSearch
-              :search="variableSearch"
+              :search="variableSearchMap[index - 1] ?? ''"
               :disabled="loadingContactFields"
               :placeholder="
                 $t('new_broadcast.pages.select_variables.variable_placeholder')
               "
-              @update:search="variableSearch = $event"
+              @update:search="(v) => (variableSearchMap[index - 1] = v)"
               @update:model-value="
                 (event: ContactFieldOption | undefined) =>
                   handleVariableUpdate(index - 1, event)
@@ -97,7 +97,7 @@ const nameFieldOption: ContactFieldOption = {
   value: NAME_FIELD_VALUE,
 };
 
-const variableSearch = ref('');
+const variableSearchMap = ref<Record<number, string>>({});
 
 const contactFields = computed(() => {
   const fields = contactStore.contactFields.map(

--- a/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
+++ b/src/components/NewBroadcast/VariablesSelection/VariablesSelection.vue
@@ -31,7 +31,7 @@
               :placeholder="
                 $t('new_broadcast.pages.select_variables.variable_placeholder')
               "
-              @update:search="(v) => (variableSearchMap[index - 1] = v)"
+              @update:search="(v: string) => (variableSearchMap[index - 1] = v)"
               @update:model-value="
                 (event: ContactFieldOption | undefined) =>
                   handleVariableUpdate(index - 1, event)

--- a/src/components/modals/ChannelSelectionModal.vue
+++ b/src/components/modals/ChannelSelectionModal.vue
@@ -21,13 +21,12 @@
       <p class="channel-selection-modal__description">
         {{ $t('modals.channel_selection.description') }}
       </p>
-      <UnnnicSelectSmart
+      <UnnnicSelect
+        returnObject
         class="channel-selection-modal__select"
         :options="channelsOptions"
         :modelValue="channelOption"
-        :isLoading="loadingChannels"
-        orderedByIndex
-        selectFirst
+        :disabled="loadingChannels"
         @update:model-value="handleChannelUpdate"
       />
     </section>
@@ -35,7 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
 import type { SelectOption } from '@/types/select';
 import { useProjectStore } from '@/stores/project';
 import { useBroadcastsStore } from '@/stores/broadcasts';
@@ -57,17 +56,15 @@ const selectedChannel = computed(() => {
   return broadcastsStore.newBroadcast.channel;
 });
 
-const channelOption = computed<SelectOption[]>(() => {
+const channelOption = computed<SelectOption | undefined>(() => {
   if (!selectedChannel.value) {
-    return [];
+    return undefined;
   }
 
-  return [
-    {
-      label: selectedChannel.value.name,
-      value: selectedChannel.value.uuid,
-    },
-  ];
+  return {
+    label: selectedChannel.value.name,
+    value: selectedChannel.value.uuid,
+  };
 });
 
 const channelsOptions = computed<SelectOption[]>(() => {
@@ -93,10 +90,9 @@ const handleSecondaryButtonClick = () => {
   handleUpdateModelValue(false);
 };
 
-const handleChannelUpdate = (newChannel: SelectOption[]) => {
-  const channelUuid = newChannel[0].value;
+const handleChannelUpdate = (option: SelectOption) => {
   const channelMatch = projectStore.wppChannels.find(
-    (channel) => channel.uuid === channelUuid,
+    (channel) => channel.uuid === option.value,
   );
   if (!channelMatch) {
     return;
@@ -104,6 +100,16 @@ const handleChannelUpdate = (newChannel: SelectOption[]) => {
 
   broadcastsStore.setChannel(channelMatch);
 };
+
+watch(
+  [channelsOptions, loadingChannels],
+  ([options, loading]) => {
+    if (!selectedChannel.value && !loading && options.length > 0) {
+      handleChannelUpdate(options[0]);
+    }
+  },
+  { immediate: true },
+);
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## Description
### Type of Change
* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [x] Refactoring (no functional changes, no api changes)
* [x] Tests
* [ ] Other

### Motivation and Context
`UnnnicSelectSmart` is being deprecated in `@weni/unnnic-system`. This PR migrates all usages in bulk_send to `UnnnicSelect`, which is the supported replacement for single-select scenarios.

No dependency bump was required — the installed version (`3.24.5-redesign.2`) already exposes `UnnnicSelect` globally via `UnnnicSystem.ts`.

### Summary of Changes
**Components migrated (5):**
- `ContactImportProcessingForm.vue` — existing group selection with search
- `ContactImportProcessingMapping.vue` — new field type selection
- `ChannelSelectionModal.vue` — WPP channel selection
- `VariablesSelection.vue` — template variable mapping
- `ConfirmForm.vue` + `useFlowSelection.ts` — flow selection on confirm-and-send

**API adaptations:**
- `modelValue` changed from `SelectOption[]` to `SelectOption | undefined` with `returnObject`
- `autocomplete` → `enableSearch` + controlled `search` ref
- `isLoading` → `:disabled="loadingX"`
- `selectFirst` in `ChannelSelectionModal` replaced by a parent watcher
- Removed props with no equivalent: `autocompleteClearOnFocus`, `autocompleteIconLeft`, `enableSearchByValue`, `orderedByIndex`

**Tests updated (6 specs):**
- Stubs renamed from `UnnnicSelectSmart` to `UnnnicSelect`
- Emit payloads updated from arrays to single objects
- Removed unused `UnnnicSelectSmart` stub from `TemplateSelectionFilters.spec.ts`

**Accepted behavioral differences:**
- Loading state disables the select instead of showing an internal spinner
- Search field appears inside the popover (not inline on the trigger)
- Options follow the order provided by the parent (no numeric reordering on filter)